### PR TITLE
doc: add QChatGPT

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ English/[简体中文](https://github.com/deepseek-ai/awesome-deepseek-integrati
         <td> <a href="https://github.com/deepseek-ai/awesome-deepseek-integration/blob/main/docs/huixiangdou/README_cn.md">HuixiangDou<br/>(wechat,lark)</a> </td>
         <td>Domain knowledge assistant in personal WeChat and Feishu, focusing on answering questions</td>
     </tr>
+    <tr>
+        <td> <img src="https://github.com/RockChinQ/QChatGPT/blob/master/res/logo.png?raw=true" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://github.com/RockChinQ/QChatGPT">QChatGPT<br/>（QQ）</a> </td>
+        <td> A QQ chatbot with high stability, plugin support, and real-time networking </td>
+        </td>
+    </tr>
 </table>
 
 ### Browser Extensions

--- a/README_cn.md
+++ b/README_cn.md
@@ -43,6 +43,11 @@
         <td> <a href="https://github.com/deepseek-ai/awesome-deepseek-integration/blob/main/docs/huixiangdou/README_cn.md">茴香豆<br/>（个人微信/飞书）</a> </td>
         <td> 一个集成到个人微信群/飞书群的领域知识助手，专注解答问题不闲聊</td>
     </tr>
+    <tr>
+        <td> <img src="https://github.com/RockChinQ/QChatGPT/blob/master/res/logo.png?raw=true" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://github.com/RockChinQ/QChatGPT">QChatGPT<br/>（QQ）</a> </td>
+        <td> 😎高稳定性、🧩支持插件、🌏实时联网的 LLM QQ / QQ频道 / One Bot 机器人🤖</td>
+    </tr>
 </table>
 
 ### 浏览器插件


### PR DESCRIPTION
## 配置方法

完成部署后，在 `data/config/provider.json` 中填写 DeepSeek 的 api_key，再设置model为`deepseek-chat`，重启即可使用