### PR TITLE
Add RAGFlow

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,15 @@ English/[简体中文](https://github.com/deepseek-ai/awesome-deepseek-integrati
     </tr>
 </table>
 
+### RAG framework
+<table>
+    <tr>
+        <td> <img src="https://github.com/deepseek-ai/awesome-deepseek-integration/assets/33142505/77093e84-9f7c-4716-9168-bac962fa1372" alt="Icon" width="160" height="auto" /> </td>
+        <td> <a href="https://github.com/infiniflow/ragflow">RAGFlow</a> </td>
+        <td> An open-source RAG (Retrieval-Augmented Generation) engine based on deep document understanding. It offers a streamlined RAG workflow for businesses of any scale, combining LLM (Large Language Models) to provide truthful question-answering capabilities, backed by well-founded citations from various complex formatted data. </td>
+    </tr>
+</table>
+
 ### IM Application Plugins
 
 <table>

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ English/[简体中文](https://github.com/deepseek-ai/awesome-deepseek-integrati
 ### RAG framework
 <table>
     <tr>
-        <td> <img src="https://github.com/deepseek-ai/awesome-deepseek-integration/assets/33142505/77093e84-9f7c-4716-9168-bac962fa1372" alt="Icon" width="160" height="auto" /> </td>
-        <td> <a href="https://github.com/infiniflow/ragflow">RAGFlow</a> </td>
+        <td> <img src="https://github.com/deepseek-ai/awesome-deepseek-integration/assets/33142505/77093e84-9f7c-4716-9168-bac962fa1372" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://github.com/deepseek-ai/awesome-deepseek-integration/blob/main/docs/ragflow/README.md"> RAGFlow </a> </td>
         <td> An open-source RAG (Retrieval-Augmented Generation) engine based on deep document understanding. It offers a streamlined RAG workflow for businesses of any scale, combining LLM (Large Language Models) to provide truthful question-answering capabilities, backed by well-founded citations from various complex formatted data. </td>
     </tr>
 </table>

--- a/README_cn.md
+++ b/README_cn.md
@@ -47,8 +47,8 @@
 ### RAG 框架
 <table>
     <tr>
-        <td> <img src="https://github.com/deepseek-ai/awesome-deepseek-integration/assets/33142505/77093e84-9f7c-4716-9168-bac962fa1372" alt="Icon" width="160" height="auto" /> </td>
-        <td> <a href="https://github.com/infiniflow/ragflow">RAGFlow</a> </td>
+        <td> <img src="https://github.com/deepseek-ai/awesome-deepseek-integration/assets/33142505/77093e84-9f7c-4716-9168-bac962fa1372" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://github.com/deepseek-ai/awesome-deepseek-integration/blob/main/docs/ragflow/README_cn.md"> RAGFlow </a> </td>
         <td> 一款基于深度文档理解构建的开源 RAG（Retrieval-Augmented Generation）引擎。RAGFlow 可以为各种规模的企业及个人提供一套精简的 RAG 工作流程，结合大语言模型（LLM）针对用户各类不同的复杂格式数据提供可靠的问答以及有理有据的引用。 </td>
     </tr>
 </table>

--- a/README_cn.md
+++ b/README_cn.md
@@ -44,6 +44,15 @@
     </tr>
 </table>
 
+### RAG 框架
+<table>
+    <tr>
+        <td> <img src="https://github.com/deepseek-ai/awesome-deepseek-integration/assets/33142505/77093e84-9f7c-4716-9168-bac962fa1372" alt="Icon" width="160" height="auto" /> </td>
+        <td> <a href="https://github.com/infiniflow/ragflow">RAGFlow</a> </td>
+        <td> 一款基于深度文档理解构建的开源 RAG（Retrieval-Augmented Generation）引擎。RAGFlow 可以为各种规模的企业及个人提供一套精简的 RAG 工作流程，结合大语言模型（LLM）针对用户各类不同的复杂格式数据提供可靠的问答以及有理有据的引用。 </td>
+    </tr>
+</table>
+
 ### 即时通讯插件
 
 <table>

--- a/docs/ragflow/README.md
+++ b/docs/ragflow/README.md
@@ -1,0 +1,14 @@
+<img src="https://github.com/deepseek-ai/awesome-deepseek-integration/assets/33142505/77093e84-9f7c-4716-9168-bac962fa1372" alt="Icon" width="64" height="auto" />
+
+# [RAGFlow](https://github.com/infiniflow/ragflow)
+
+An open-source RAG (Retrieval-Augmented Generation) engine based on deep document understanding. It offers a streamlined RAG workflow for businesses of any scale, combining LLM (Large Language Models) to provide truthful question-answering capabilities, backed by well-founded citations from various complex formatted data.
+
+## UI
+
+![image](https://github.com/deepseek-ai/awesome-deepseek-integration/assets/33142505/a69ce143-931c-4a75-b129-f6a1ddd114a2)
+
+
+## Integrate with Deepseek API
+
+![image](https://github.com/deepseek-ai/awesome-deepseek-integration/assets/33142505/49dc1916-c3c2-470a-a3ea-b5877de52958)

--- a/docs/ragflow/README_cn.md
+++ b/docs/ragflow/README_cn.md
@@ -1,0 +1,14 @@
+<img src="https://github.com/deepseek-ai/awesome-deepseek-integration/assets/33142505/77093e84-9f7c-4716-9168-bac962fa1372" alt="Icon" width="64" height="auto" />
+
+# [RAGFlow](https://github.com/infiniflow/ragflow)
+
+一款基于深度文档理解构建的开源 RAG（Retrieval-Augmented Generation）引擎。RAGFlow 可以为各种规模的企业及个人提供一套精简的 RAG 工作流程，结合大语言模型（LLM）针对用户各类不同的复杂格式数据提供可靠的问答以及有理有据的引用。
+
+## UI
+
+![image](https://github.com/deepseek-ai/awesome-deepseek-integration/assets/33142505/a69ce143-931c-4a75-b129-f6a1ddd114a2)
+
+
+## 配置 Deepseek API
+
+![image](https://github.com/deepseek-ai/awesome-deepseek-integration/assets/33142505/514b87e3-2eef-4dd2-b21d-88bb3f381573)


### PR DESCRIPTION
RAGFlow: https://github.com/infiniflow/ragflow, An open source RAG engine which default LLM is DeepSeek-V2. I would like to add it to deepseek integration repo.