### PR TITLE
Update continue README.md

### DIFF
--- a/docs/continue/README.md
+++ b/docs/continue/README.md
@@ -25,7 +25,7 @@ Please use the following config before we release official FIM support:
     "model": "deepseek-coder",
     "apiBase": "https://api.deepseek.com",
     "apiType": "openai",
-    "apikey": REDACTED,
+    "apiKey": REDACTED,
     "useLegacyCompletionsEndpoint": false,
     "contextLength": 8192
   }],


### PR DESCRIPTION
Because the apiKey key value is misspelled, it causes authentication failure when using the plugin. #20