### PR TITLE
Update README.md

### DIFF
--- a/docs/continue/README.md
+++ b/docs/continue/README.md
@@ -27,16 +27,14 @@ Continue will generate, refactor, and explain entire sections of code with LLMs.
       "model": "deepseek-chat",
       "contextLength": 128000,
       "apiKey": "REDACTED",
-      "provider": "openai",
-      "apiBase": "https://api.deepseek.com/beta"
+      "provider": "deepseek"
     }
   ],
   "tabAutocompleteModel": {
     "title": "DeepSeek",
     "model": "deepseek-chat",
     "apiKey": "REDACTED",
-    "provider": "openai",
-    "apiBase": "https://api.deepseek.com/beta"
+    "provider": "deepseek"
   },
 ...
 ```


### PR DESCRIPTION
Continue has first-class support for Deepseek, so it's not necessary to set the `apiBase`