### PR TITLE
Update README.md - Add LiteLLM integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,4 +239,9 @@ English/[简体中文](https://github.com/deepseek-ai/awesome-deepseek-integrati
         <td> <a href="https://github.com/rubickecho/n8n-deepseek"> n8n-nodes-deepseek </a> </td>
         <td> An N8N community node that supports direct integration with the DeepSeek API into workflows. </td>
     </tr>
+    <tr>
+        <td> <img src="https://framerusercontent.com/images/8rF2JOaZ8l9AvM4H6ezliw44aI.png" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://github.com/BerriAI/litellm"> LiteLLM </a> </td>
+        <td> Python SDK, Proxy Server (LLM Gateway) to call 100+ LLM APIs in OpenAI format. Supports DeepSeek AI with cost tracking as well. </td>
+    </tr>
 </table>


### PR DESCRIPTION
Hi @berry-13 @Kurama622 

This PR adds LiteLLM integration to the deepseek docs. You can see our documentation [here](https://docs.litellm.ai/docs/providers/deepseek). 

We recently added deepseek r-1 support as well - https://github.com/BerriAI/litellm/issues/7877#issuecomment-2608261249