### PR TITLE
Docs: Add Mem0

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,4 +249,9 @@ English/[简体中文](https://github.com/deepseek-ai/awesome-deepseek-integrati
         <td> <a href="https://github.com/BerriAI/litellm"> LiteLLM </a> </td>
         <td> Python SDK, Proxy Server (LLM Gateway) to call 100+ LLM APIs in OpenAI format. Supports DeepSeek AI with cost tracking as well. </td>
     </tr>
+     <tr>
+        <td> <img src="https://framerusercontent.com/images/8rF2JOaZ8l9AvM4H6ezliw44aI.png" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://github.com/mem0ai/mem0"> Mem0 </a> </td>
+        <td> Mem0 enhances AI assistants with an intelligent memory layer, enabling personalized interactions and continuous learning over time. </td>
+    </tr>
 </table>


### PR DESCRIPTION
Mem0 now support Deepseek as an LLM provider!

Doc: https://docs.mem0.ai/components/llms/models/deepseek