### PR TITLE
Add Emacs section - add `gptel` and `minuet-ai`

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,20 @@ English/[简体中文](https://github.com/deepseek-ai/awesome-deepseek-integrati
     </tr>
 </table>
 
+### Emacs
+
+<table>
+    <tr>
+        <td> <img src="https://upload.wikimedia.org/wikipedia/commons/0/08/EmacsIcon.svg" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://github.com/karthink/gptel"> gptel </a> </td>
+        <td>A simple LLM client for Emacs</td>
+    </tr>
+    <tr>
+        <td> <img src="https://upload.wikimedia.org/wikipedia/commons/0/08/EmacsIcon.svg" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://github.com/milanglacier/minuet-ai.el"> Minuet AI </a> </td>
+        <td>Dance with Intelligence in Your Code 💃</td>
+    </tr>
+</table>
 ### Others
 
 <table>

--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ English/[简体中文](https://github.com/deepseek-ai/awesome-deepseek-integrati
         <td>Dance with Intelligence in Your Code 💃</td>
     </tr>
 </table>
+
 ### Others
 
 <table>


### PR DESCRIPTION
Add new section for Emacs, with two integrations that support DeepSeek:
- [x] `gptel` _(tested by me, DeepSeek support documented)_ 
- [x] `minuet-ai.el` _(DeepSeek support documented)_

(This is a replacement for PR #100, as the links are not correct in that PR and I think Emacs can have it's own section :))