### PR TITLE
Move Geneplore AI listing to its own category, add docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,16 @@ English/[简体中文](https://github.com/deepseek-ai/awesome-deepseek-integrati
     </tr>
 </table>
 
+### Discord Bots
+
+<table>
+    <tr>
+        <td> <img src="https://geneplore.com/img/geneplore_color_logo_circular.png" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://geneplore.com/bot"> Geneplore AI </a> </td>
+        <td> Geneplore AI runs one of the largest AI Discord bots, now with Deepseek v3 and R1. </td>
+    </tr>
+</table>
+
 ### Cursor
 
 <table>
@@ -322,11 +332,6 @@ English/[简体中文](https://github.com/deepseek-ai/awesome-deepseek-integrati
         <td> <img src="https://i.postimg.cc/k5Z4YWjt/Screenshot-2025-01-23-at-6-08-01-PM.png" alt="Icon" width="64" height="auto" /> </td>
         <td> <a href="https://github.com/mem0ai/mem0"> Mem0 </a> </td>
         <td> Mem0 enhances AI assistants with an intelligent memory layer, enabling personalized interactions and continuous learning over time. </td>
-    </tr>
-    <tr>
-        <td> <img src="https://geneplore.com/img/geneplore_color_logo_circular.png" alt="Icon" width="64" height="auto" /> </td>
-        <td> <a href="https://geneplore.com/bot"> Geneplore AI </a> </td>
-        <td> Geneplore AI runs one of the largest AI Discord bots, now with Deepseek v3 and R1. </td>
     </tr>
     <tr>
         <td> <img src="https://www.promptfoo.dev/img/logo-panda.svg" alt="Icon" width="64" height="auto" /> </td>

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ English/[简体中文](https://github.com/deepseek-ai/awesome-deepseek-integrati
 <table>
     <tr>
         <td> <img src="https://geneplore.com/img/geneplore_color_logo_circular.png" alt="Icon" width="64" height="auto" /> </td>
-        <td> <a href="https://geneplore.com/bot"> Geneplore AI </a> </td>
+        <td> <a href="docs/Geneplore AI/README.md"> Geneplore AI </a> </td>
         <td> Geneplore AI runs one of the largest AI Discord bots, now with Deepseek v3 and R1. </td>
     </tr>
 </table>

--- a/docs/Geneplore AI/README.md
+++ b/docs/Geneplore AI/README.md
@@ -2,7 +2,7 @@
 
 ## Geneplore AI is building the world's easiest way to use AI - Use 50+ models, all on Discord
 
-Chat with the all-new Deepseek v3, GPT-4o, Claude 3 Opus, LLaMA 3, Gemini Pro, FLUX.1, and ChatGPT with **one bot**. Generate videos with Stable Diffusion Video, and images with the newest and most popular models available.
+Chat with the all-new Deepseek v3, GPT-4o, Claude 3 Opus, LLaMA 3, Gemini Pro, FLUX.1, and ChatGPT with **one bot**. Generate videos with Stable Diffusion Video, and images with the newest and most popular models available. No more fiddling with API keys and webhooks - every model is completely integrated into the bot.
 
 Don't like how the bot responds? Simply change the model in *seconds* and continue chatting like normal, without adding another bot to your server.
 

--- a/docs/Geneplore AI/README.md
+++ b/docs/Geneplore AI/README.md
@@ -1,0 +1,17 @@
+# [Geneplore AI](https://geneplore.com/bot)
+
+## Geneplore AI is building the world's easiest way to use AI - Use 50+ models, all on Discord
+
+Chat with the all-new Deepseek v3, GPT-4o, Claude 3 Opus, LLaMA 3, Gemini Pro, FLUX.1, and ChatGPT with **one bot**. Generate videos with Stable Diffusion Video, and images with the newest and most popular models available.
+
+Don't like how the bot responds? Simply change the model in *seconds* and continue chatting like normal, without adding another bot to your server.
+
+**NEW:** Try the most powerful open AI model, Deepseek v3, for free with our bot. Simply type /chat and select Deepseek in the model list.
+
+![image](https://github.com/user-attachments/assets/14db7e3c-c2c7-46d7-9fe1-5a5d1e3fc856)
+
+Use the bot trusted by over 60,000 servers and hundreds of paying subscribers, without the hassle of multiple $20/month subscriptions and complicated programming.
+
+https://geneplore.com
+
+© 2025 Geneplore AI, All Rights Reserved.

--- a/docs/Geneplore AI/README.md
+++ b/docs/Geneplore AI/README.md
@@ -2,9 +2,9 @@
 
 ## Geneplore AI is building the world's easiest way to use AI - Use 50+ models, all on Discord
 
-Chat with the all-new Deepseek v3, GPT-4o, Claude 3 Opus, LLaMA 3, Gemini Pro, FLUX.1, and ChatGPT with **one bot**. Generate videos with Stable Diffusion Video, and images with the newest and most popular models available. No more fiddling with API keys and webhooks - every model is completely integrated into the bot.
+Chat with the all-new Deepseek v3, GPT-4o, Claude 3 Opus, LLaMA 3, Gemini Pro, FLUX.1, and ChatGPT with **one bot**. Generate videos with Stable Diffusion Video, and images with the newest and most popular models available.
 
-Don't like how the bot responds? Simply change the model in *seconds* and continue chatting like normal, without adding another bot to your server.
+Don't like how the bot responds? Simply change the model in *seconds* and continue chatting like normal, without adding another bot to your server. No more fiddling with API keys and webhooks - every model is completely integrated into the bot.
 
 **NEW:** Try the most powerful open AI model, Deepseek v3, for free with our bot. Simply type /chat and select Deepseek in the model list.
 


### PR DESCRIPTION
I created a new category called Discord Bots, where Geneplore AI now lives. I also added a folder in docs/ for Geneplore AI, and the link now goes to there.