### PR TITLE
Add hustcer/deepseek-review for code review locally or in GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ English/[简体中文](https://github.com/deepseek-ai/awesome-deepseek-integrati
     <tr>
         <td> <img src="https://www.gptaiflow.tech/logo.png" alt="gpt-ai-flow-logo" width="64" height="auto" /> </td>
         <td> <a href="https://www.gptaiflow.tech/docs/product/api-keys-setup#setup-deepseek-api-keys">GPT AI Flow</a></td>
-        <td> 
+        <td>
             The ultimate productivity weapon built by engineers for efficiency enthusiasts (themselves): <a href="https://www.gptaiflow.tech/">GPT AI Flow</a>
             <ul>
                 <li>`Shift+Alt+Space` Wake up desktop intelligent hub</li>
@@ -382,5 +382,10 @@ English/[简体中文](https://github.com/deepseek-ai/awesome-deepseek-integrati
         <td> <img src="https://www.promptfoo.dev/img/logo-panda.svg" alt="Icon" width="64" height="auto" /> </td>
         <td> <a href="docs/promptfoo/README.md"> promptfoo </a> </td>
         <td> Test and evaluate LLM prompts, including DeepSeek models. Compare different LLM providers, catch regressions, and evaluate responses. </td>
+    </tr>
+    <tr>
+        <td> CR </td>
+        <td> <a href="https://github.com/hustcer/deepseek-review"> deepseek-review </a> </td>
+        <td> 🚀 Sharpen Your Code, Ship with Confidence! Let's do code review with Deepseek! 🚀 </td>
     </tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -386,6 +386,6 @@ English/[简体中文](https://github.com/deepseek-ai/awesome-deepseek-integrati
     <tr>
         <td> CR </td>
         <td> <a href="https://github.com/hustcer/deepseek-review"> deepseek-review </a> </td>
-        <td> 🚀 Sharpen Your Code, Ship with Confidence! Let's do code review with Deepseek! 🚀 </td>
+        <td> 🚀 Sharpen Your Code, Ship with Confidence – Elevate Your Workflow with Deepseek Code Review 🚀 </td>
     </tr>
 </table>

--- a/README_cn.md
+++ b/README_cn.md
@@ -282,4 +282,9 @@
         <td> <a href="docs/promptfoo/README.md"> promptfoo </a> </td>
         <td> 测试和评估LLM提示，包括DeepSeek模型。比较不同的LLM提供商，捕获回归，并评估响应。 </td>
     </tr>
+    <tr>
+        <td> CR </td>
+        <td> <a href="https://github.com/hustcer/deepseek-review"> deepseek-review </a> </td>
+        <td> 🚀 使用 Deepseek 进行代码审核，支持 GitHub Action 和本地 🚀 </td>
+    </tr>
 </table>


### PR DESCRIPTION
Add [hustcer/deepseek-review](https://github.com/hustcer/deepseek-review) for code reviews with DeepSeek. It works seamlessly both locally and in GitHub Actions.

Review example: https://github.com/hustcer/deepseek-review/pull/17

## Features

- Automate PR Reviews with Deepseek via GitHub Action
- Review Remote GitHub PRs Directly from Your Local CLI
- Analyze Commit Changes with Deepseek for Any Local Repository with CLI
- Fully Customizable: Choose Models, Base URLs, and Prompts
- Supports Self-Hosted Deepseek Models for Enhanced Flexibility
- Add `skip cr` or `skip review` to PR title or body to disable code review in GitHub Actions
- Cross-platform Support: Compatible with GitHub Runners across `macOS`, `Ubuntu`, and `Windows`

