### PR TITLE
feat: fix markdown rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,12 +155,10 @@ English/[简体中文](https://github.com/deepseek-ai/awesome-deepseek-integrati
         <td> <a href="https://bobtranslate.com/">STranslate</a></td>
         <td> <a href="https://bobtranslate.com/">STranslate</a>（Windows） is a ready-to-go translation ocr tool developed by WPF </td>
     </tr>
-
      <tr>
         <td> <img src="https://github.com/user-attachments/assets/5e16beb0-993e-47bf-807e-7c8804b313a2" alt="Asp Client" width="64" height="auto" /> </td>
         <td> <a href="https://github.com/Anwar-alhitar/Deepseek.Asp.Client/blob/master/README.md">ASP Client</a> </td>
         <td><a href="https://github.com/Anwar-alhitar/Deepseek.Asp.Client/blob/master/README.md">Deepseek.ASPClient</a>  is a lightweight ASP.NET wrapper for the Deepseek AI API, designed to simplify AI-driven text processing in .NET applications.. </td>
-
     </tr>
     <tr>
         <td> <img src="https://www.gptaiflow.tech/logo.png" alt="gpt-ai-flow-logo" width="64" height="auto" /> </td>


### PR DESCRIPTION
Fix the broken table rendering due to extra new line introduced in one of the PRs.

Before fix:
![Screenshot 2025-02-06 at 2 02 44 PM](https://github.com/user-attachments/assets/09bd62e1-e64d-4237-93bc-f4a24153218a)


After fix:

![Screenshot 2025-02-06 at 2 02 54 PM](https://github.com/user-attachments/assets/4c679c8a-1522-4288-bc84-d5cf9d0cc303)
