### PR TITLE
updated solana-agent-kit hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ English/[简体中文](https://github.com/deepseek-ai/awesome-deepseek-integrati
 <table>
     <tr>
         <td> <img src="./docs/solana-agent-kit/assets/sendai-logo.png" alt="Icon" width="128" height="auto" /> </td>
-        <td> <a href="https://github.com/deepseek-ai/awesome-deepseek-integration/blob/main/docs/ragflow/README.md"> Solana Agent Kit </a> </td>
+        <td> <a href="https://github.com/deepseek-ai/awesome-deepseek-integration/blob/main/docs/solana-agent-kit/README.md"> Solana Agent Kit </a> </td>
         <td>An open-source toolkit for connecting AI agents to Solana protocols. Now, any agent, using any Deepseek LLM, can autonomously perform 60+ Solana actions: </td>
     </tr>
 </table>


### PR DESCRIPTION
Previously the solana-agent-kit URL was pointing to [RAGFlow Readme](https://github.com/deepseek-ai/awesome-deepseek-integration/blob/main/docs/ragflow/README.md):

I have made the following changes, so that the hyperlink in the readme, points to the correct docs:
- added hyperlink that points to the correct solana-agent-kit [readme file](https://github.com/deepseek-ai/awesome-deepseek-integration/blob/main/docs/solana-agent-kit/README.md) and not RAG.

