### PR TITLE
docs: add ChatGOT to integration list

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,11 @@ English/[简体中文](https://github.com/deepseek-ai/awesome-deepseek-integrati
         <td> <a href="https://rssflow.oinchain.com"> RssFlow </a> </td>
         <td>An intelligent RSS reader browser extension with AI-powered RSS summarization and multi-dimensional feed views. Supports DeepSeek model configuration for enhanced content understanding. </td>
     </tr>
+    <tr>
+        <td> <img src="https://www.chatgot.io/chat/assets/imgs/logo@2x.png" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://www.chatgot.io/"> ChatGOT </a> </td>
+        <td> A free AI chatbot assistant for enhancing productivity </td>
+    </tr>
 </table>
 
 ### VS Code Extensions

--- a/README_cn.md
+++ b/README_cn.md
@@ -246,6 +246,11 @@
         <td> <a href="https://rssflow.oinchain.com"> RssFlow </a> </td>
         <td>一款智能的RSS阅读器浏览器扩展，具有AI驱动的RSS摘要和多维度订阅视图功能。支持配置DeepSeek模型以增强内容理解能力。</td>
     </tr>
+    <tr>
+        <td> <img src="https://www.chatgot.io/chat/assets/imgs/logo@2x.png" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://www.chatgot.io/"> ChatGOT </a> </td>
+        <td> 一个免费的AI聊天机器人助手，用于提高生产力 </td>
+    </tr>
 </table>
 
 ### VS Code 插件

--- a/README_ja.md
+++ b/README_ja.md
@@ -228,6 +228,11 @@ DeepSeek APIを人気のソフトウェアに統合します。APIキーを取�
         <td> <a href="https://rssflow.oinchain.com"> RssFlow </a> </td>
         <td>AIを活用したRSS要約と多次元フィードビューを備えたインテリジェントなRSSリーダーブラウザ拡張機能。コンテンツ理解を強化するためのDeepSeekモデル設定をサポートしています。</td>
     </tr>
+    <tr>
+        <td> <img src="https://www.chatgot.io/chat/assets/imgs/logo@2x.png" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://www.chatgot.io/"> ChatGOT </a> </td>
+        <td> 生産性を向上させるための無料のAIチャットボットアシスタント </td>
+    </tr>
 </table>
 
 ### VS Code拡張機能


### PR DESCRIPTION
ChatGOT is a software which is seemlessly integrated with DeepSeek and other multiple cutting-edge AI models for boost work and study efficiency.