### PR TITLE
README:  increase logo size

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ English/[简体中文](https://github.com/deepseek-ai/awesome-deepseek-integrati
         <td>The world's first autonomous general AI with advanced cognitive architecture and human-like reasoning capabilities, designed to tackle complex real-world challenges.</td>
     </tr>
     <tr>
-        <td> <img src="https://maxkb.cn/images/favicon.png" alt="Icon" width="64" height="auto" /> </td>
+        <td> <img src="https://maxkb.cn/images/favicon.png" alt="Icon" width="256" height="auto" /> </td>
         <td> <a href="https://github.com/1Panel-dev/MaxKB">MaxKB</a> </td>
         <td> <a href="https://maxkb.cn/">MaxKB</a> is a ready-to-use, flexible RAG Chatbot. </td>
     </tr>      


### PR DESCRIPTION
In the README, the default logo size is set to 64, which is too small. Consider increasing it to 256.

before:
![image](https://github.com/user-attachments/assets/5c7adb2f-9cbb-4ed3-8cd0-9642db9f489d)

after: 
![image](https://github.com/user-attachments/assets/54f5d4f1-a977-412d-81c4-d776d07d6243)
