### PR TITLE
perf: update td width

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ English/[简体中文](https://github.com/deepseek-ai/awesome-deepseek-integrati
 
 <table>
     <tr>
-        <td> <img src="https://avatars.githubusercontent.com/u/171659527?s=400&u=39906ab3b6e2066f83046096a66a77fb3f8bb836&v=4" alt="Icon" width="64" height="auto" /> </td>
+        <td width=80> <img src="https://avatars.githubusercontent.com/u/171659527?s=400&u=39906ab3b6e2066f83046096a66a77fb3f8bb836&v=4" alt="Icon" width="64" height="auto" /> </td>
         <td> <a href="https://github.com/quantalogic/quantalogic">Quantalogic</a> </td>
         <td> QuantaLogic is a ReAct (Reasoning & Action) framework for building advanced AI agents. </td>
     </tr>


### PR DESCRIPTION
May be using this style better than before

In the README, the default logo size is set to 64, which is too small. Consider increasing it to 256.

before:
![image](https://github.com/user-attachments/assets/5c7adb2f-9cbb-4ed3-8cd0-9642db9f489d)

after: 
![image](https://github.com/user-attachments/assets/54f5d4f1-a977-412d-81c4-d776d07d6243)

Close #288