### PR TITLE
Update the config.json of the 'continue' integration

### DIFF
--- a/docs/continue/README.md
+++ b/docs/continue/README.md
@@ -27,7 +27,7 @@ Continue will generate, refactor, and explain entire sections of code with LLMs.
       "model": "deepseek-chat",
       "contextLength": 128000,
       "apiKey": "REDACTED",
-      "provider": "deepseek",
+      "provider": "openai",
       "apiBase": "https://api.deepseek.com/beta"
     }
   ],
@@ -35,7 +35,7 @@ Continue will generate, refactor, and explain entire sections of code with LLMs.
     "title": "DeepSeek",
     "model": "deepseek-chat",
     "apiKey": "REDACTED",
-    "provider": "deepseek",
+    "provider": "openai",
     "apiBase": "https://api.deepseek.com/beta"
   },
 ...


### PR DESCRIPTION
I have tried to use deepseek api in continue (the extension of VSCode which helps to code with AI). 
It seems that the config.json code block show different "provider" value compared to the picture that below the code block. 
I have tried both. **"provider": "openai"** works for me. So I think the "provider" in code block needs to be amended.