### PR TITLE
docs: Add AstrBot into integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,11 @@ English/[简体中文](https://github.com/deepseek-ai/awesome-deepseek-integrati
         <td> <a href="https://github.com/KomoriDev/nonebot-plugin-deepseek">NoneBot<br/>（QQ, Lark, Discord, TG, etc.）</a> </td>
         <td> Based on NoneBot framework, provide intelligent chat and deep thinking functions, supports QQ, Lark, Discord, TG, and more platforms.</td>
     </tr>
+    <tr>
+        <td> <img src="https://github.com/Soulter/AstrBot/raw/refs/heads/master/dashboard/src/assets/images/logo-normal.svg" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://github.com/Soulter/AstrBot/">AstrBot<br/>（QQ, WeChat, WeCom, Lark, TG, etc.）</a> </td>
+        <td> User-friendly LLM-based multi-platform chatbot with a WebUI, supporting long-term-memory, RAG, LLM agents, and plugins integration.</td>
+    </tr>
 </table>
 
 ### Browser Extensions

--- a/README_cn.md
+++ b/README_cn.md
@@ -342,6 +342,11 @@
         <td> <a href="https://github.com/KomoriDev/nonebot-plugin-deepseek">NoneBot<br/>（QQ, 飞书, Discord, TG, etc.）</a> </td>
         <td> 基于 NoneBot 框架，支持智能对话与深度思考功能。适配 QQ / 飞书 / Discord, TG 等多种消息平台 </td>
     </tr>
+    <tr>
+        <td> <img src="https://github.com/Soulter/AstrBot/raw/refs/heads/master/dashboard/src/assets/images/logo-normal.svg" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://github.com/Soulter/AstrBot/">AstrBot<br/>（QQ, 微信, 企微, 飞书, TG, etc.）</a> </td>
+        <td> 支持大模型的多平台聊天机器人及开发框架。支持 RAG、长期记忆以及网页搜索等各种 LLM Agent 功能, 支持插件开发。</td>
+    </tr>
 </table>
 
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -316,6 +316,11 @@ DeepSeek API を人気のソフトウェアに統合します。API キーを取
         <td> <a href="https://github.com/KomoriDev/nonebot-plugin-deepseek"">NoneBot<br/>（QQ, Lark, Discord, TG, etc.）</a> </td>
         <td> NoneBotフレームワークを基に、インテリジェントな会話と深い思考機能をサポートします。QQ/飛書/Discord/Telegram等多种多様なメッセージプラットフォームに対応しています </td>
     </tr>
+    <tr>
+        <td> <img src="https://github.com/Soulter/AstrBot/raw/refs/heads/master/dashboard/src/assets/images/logo-normal.svg" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://github.com/Soulter/AstrBot/">AstrBot<br/>（QQ, WeChat, WeCom, Lark, TG, etc.）</a> </td>
+        <td> 大規模言語モデルをサポートするマルチプラットフォームチャットボットおよび開発フレームワーク。RAG、長期記憶、ウェブ検索などの各種LLMエージェント機能をサポートし、プラグイン開発にも対応。</td>
+    </tr>
 </table>
 
 ### ブラウザ拡張機能


### PR DESCRIPTION
AstrBot is a user-friendly LLM-based multi-platform chatbot with a WebUI, supporting long-term-memory, RAG, LLM agents, and plugins integration.

Repo: https://github.com/Soulter/AstrBot
Related docs: 
- [Integrating with Ollama to use DeepSeek-R1](https://astrbot.app/config/providers/provider-ollama.html#%E6%8E%A5%E5%85%A5-ollama-%E4%BD%BF%E7%94%A8-deepseek-r1-%E7%AD%89%E6%A8%A1%E5%9E%8B)
- [Integrating with LM Studio to use DeepSeek-R1](https://astrbot.app/config/providers/provider-lmstudio.html#%E6%8E%A5%E5%85%A5-lm-studio-%E4%BD%BF%E7%94%A8-deepseek-r1-%E7%AD%89%E6%A8%A1%E5%9E%8B)
- [Integrating with DeepSeek official API to use DeepSeek models](https://astrbot.app/others/provider.html#deepseek)