### PR TITLE
添加四款可以调用DeepSeek的软件或插件

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,12 @@ English/[简体中文](https://github.com/deepseek-ai/awesome-deepseek-integrati
         <td> <img src="./docs/PopAi/assets/logo.svg" alt="PopAi" width="64" height="auto" /> </td>
         <td> <a href="https://popai.pro">PopAi</a> </td>
         <td>PopAi launches DeepSeek R1!  Enjoy lag-free, lightning-fast performance with PopAi. Seamlessly toggle online search on/off.</td>
-     </tr>
+    </tr>
+    <tr>
+        <td> <img src="https://pot-app.com/logo/icon.svg" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://pot-app.com/">Pot</a></td>
+        <td> <a href="https://pot-app.com/">Pot</a> 🌈 A cross-platform software for text translation and recognition. </td>
+    </tr>
 </table>
 
 ### AI Agent frameworks

--- a/README.md
+++ b/README.md
@@ -584,6 +584,11 @@ The purpose is to build infrastructure in the field of large models, through the
         <td> <a href="https://github.com/titusTong/seekCodeCopilot/blob/main/README.md"> SeekCode Copilot </a> </td>
         <td> vscode intelligent coding assistant supports configuring locally deployed DeepSeek models </td>
     </tr>
+    <tr>
+        <td> <img src="https://github.com/intellism/vscode-comment-translate/blob/master/doc/image/icon.png" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://github.com/intellism/vscode-comment-translate/blob/master/README.md"> Comment Translation </a> </td>
+        <td> This extension helps developers translate comments, strings, code hints, error messages, and variable names in their code. </td>
+    </tr>
 </table>
 
 ### Visual Studio Extensions

--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ English/[简体中文](https://github.com/deepseek-ai/awesome-deepseek-integrati
         <td> <a href="https://pot-app.com/">Pot</a> 🌈 A cross-platform software for text translation and recognition. </td>
     </tr>
     <tr>
-        <td><img src="" alt="Icon" width="64" height="auto" /></td>
+        <td><img src="https://github.com/Byaidu/PDFMathTranslate/raw/main/docs/images/banner.png" alt="Icon" width="64" height="auto" /></td>
         <td><a href="https://github.com/Byaidu/PDFMathTranslate">PDFMathTranslate</a></td>
         <td>PDF Math Translate is an AI-based full-text bilingual translation tool that fully preserves the layout of PDF documents.</td>
     </tr>

--- a/README.md
+++ b/README.md
@@ -325,6 +325,11 @@ English/[简体中文](https://github.com/deepseek-ai/awesome-deepseek-integrati
         <td> <a href="https://pot-app.com/">Pot</a></td>
         <td> <a href="https://pot-app.com/">Pot</a> 🌈 A cross-platform software for text translation and recognition. </td>
     </tr>
+    <tr>
+        <td><img src="" alt="Icon" width="64" height="auto" /></td>
+        <td><a href="https://github.com/Byaidu/PDFMathTranslate">PDFMathTranslate</a></td>
+        <td>PDF Math Translate is an AI-based full-text bilingual translation tool that fully preserves the layout of PDF documents.</td>
+    </tr>
 </table>
 
 ### AI Agent frameworks

--- a/README.md
+++ b/README.md
@@ -330,6 +330,11 @@ English/[简体中文](https://github.com/deepseek-ai/awesome-deepseek-integrati
         <td><a href="https://github.com/Byaidu/PDFMathTranslate">PDFMathTranslate</a></td>
         <td>PDF Math Translate is an AI-based full-text bilingual translation tool that fully preserves the layout of PDF documents.</td>
     </tr>
+    <tr>
+        <td><img src="https://github.com/Richasy/Bili.Copilot/raw/master/assets/StoreLogo.png" alt="Icon" width="64" height="auto" /></td>
+        <td><a href="https://github.com/Richasy/Bili.Copilot">Bili.Copilot</a></td>
+        <td>Bilibili third-party Windows desktop client, a native application built with the Windows App SDK.</td>
+    </tr>
 </table>
 
 ### AI Agent frameworks

--- a/README_cn.md
+++ b/README_cn.md
@@ -269,7 +269,7 @@
         <td> <a href="https://pot-app.com/">Pot</a> 🌈一个跨平台的划词翻译和OCR软件 </td>
     </tr>
     <tr>
-        <td><img src="" alt="Icon" width="64" height="auto" /></td>
+        <td><img src="https://github.com/Byaidu/PDFMathTranslate/raw/main/docs/images/banner.png" alt="Icon" width="64" height="auto" /></td>
         <td><a href="https://github.com/Byaidu/PDFMathTranslate">PDFMathTranslate</a></td>
         <td>PDFMathTranslate是一款基于 AI 完整保留排版的 PDF 文档全文双语翻译工具。</td>
     </tr>

--- a/README_cn.md
+++ b/README_cn.md
@@ -491,6 +491,11 @@
         <td> <a href="https://github.com/titusTong/seekCodeCopilot/blob/main/README.md"> SeekCode Copilot </a> </td>
         <td> vscode智能编码助手，支持配置本地部署的DeepSeek模型 </td>
     </tr>
+    <tr>
+        <td> <img src="https://github.com/intellism/vscode-comment-translate/blob/master/doc/image/icon.png" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://github.com/intellism/vscode-comment-translate/blob/master/doc/README_ZH.md"> Comment Translation </a> </td>
+        <td> 这款扩展程序能够帮助开发者翻译代码中的注释、字符串、代码提示、错误信息以及变量名。 </td>
+    </tr>
 </table>
 
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -273,6 +273,11 @@
         <td><a href="https://github.com/Byaidu/PDFMathTranslate">PDFMathTranslate</a></td>
         <td>PDFMathTranslate是一款基于 AI 完整保留排版的 PDF 文档全文双语翻译工具。</td>
     </tr>
+    <tr>
+        <td><img src="https://github.com/Richasy/Bili.Copilot/raw/master/assets/StoreLogo.png" alt="Icon" width="64" height="auto" /></td>
+        <td><a href="https://github.com/Richasy/Bili.Copilot">哔哩助理</a></td>
+        <td>B站第三方 Windows 桌面客户端，使用 Windows App SDK 构建的原生应用。</td>
+    </tr>
 </table>
 
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -268,6 +268,11 @@
         <td> <a href="https://pot-app.com/">Pot</a></td>
         <td> <a href="https://pot-app.com/">Pot</a> 🌈一个跨平台的划词翻译和OCR软件 </td>
     </tr>
+    <tr>
+        <td><img src="" alt="Icon" width="64" height="auto" /></td>
+        <td><a href="https://github.com/Byaidu/PDFMathTranslate">PDFMathTranslate</a></td>
+        <td>PDFMathTranslate是一款基于 AI 完整保留排版的 PDF 文档全文双语翻译工具。</td>
+    </tr>
 </table>
 
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -263,6 +263,11 @@
         <td> <a href="https://popai.pro">PopAi</a> </td>
         <td>PopAi推出DeepSeek R1！享受无延迟、闪电般快速的性能，尽在PopAi。轻松切换在线搜索开/关。</td>
     </tr>
+    <tr>
+        <td> <img src="https://pot-app.com/logo/icon.svg" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://pot-app.com/">Pot</a></td>
+        <td> <a href="https://pot-app.com/">Pot</a> 🌈一个跨平台的划词翻译和OCR软件 </td>
+    </tr>
 </table>
 
 

--- a/README_es.md
+++ b/README_es.md
@@ -331,6 +331,11 @@ Integra la API de DeepSeek en softwares populares. Accede a la [Plataforma Abier
         <td><a href="https://github.com/Byaidu/PDFMathTranslate">PDFMathTranslate</a></td>
         <td>Esta extensión puede ayudar a los desarrolladores a traducir anotaciones, cadenas, consejos de código, mensajes de error y nombres de variables en el Código.</td>
     </tr>
+    <tr>
+        <td><img src="https://github.com/Richasy/Bili.Copilot/raw/master/assets/StoreLogo.png" alt="Icon" width="64" height="auto" /></td>
+        <td><a href="https://github.com/Richasy/Bili.Copilot">Bili.Copilot</a></td>
+        <td>Cliente de escritorio Windows de terceros en la estación b, una aplicación nativa construida con el SDK de la aplicación Windows.</td>
+    </tr>
 </table>
 
 ### Marcos de agentes de IA

--- a/README_es.md
+++ b/README_es.md
@@ -324,7 +324,7 @@ Integra la API de DeepSeek en softwares populares. Accede a la [Plataforma Abier
     <tr>
         <td> <img src="https://pot-app.com/logo/icon.svg" alt="Icon" width="64" height="auto" /> </td>
         <td> <a href="https://pot-app.com/">Pot</a></td>
-        <td> <a href="https://pot-app.com/">Pot</a> 🌈 A cross-platform software for text translation and recognition. </td>
+        <td> <a href="https://pot-app.com/">Pot</a> 🌈 Un software multiplataforma de traducción de palabras y OCR. </td>
     </tr>
 </table>
 

--- a/README_es.md
+++ b/README_es.md
@@ -321,6 +321,11 @@ Integra la API de DeepSeek en softwares populares. Accede a la [Plataforma Abier
         <td> <a href="https://popai.pro">PopAi</a> </td>
         <td>PopAi lanza DeepSeek R1. Disfruta de un rendimiento ultrarrápido sin retrasos con PopAi. Cambia sin problemas la búsqueda en línea activada/desactivada.</td>
      </tr>
+    <tr>
+        <td> <img src="https://pot-app.com/logo/icon.svg" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://pot-app.com/">Pot</a></td>
+        <td> <a href="https://pot-app.com/">Pot</a> 🌈 A cross-platform software for text translation and recognition. </td>
+    </tr>
 </table>
 
 ### Marcos de agentes de IA

--- a/README_es.md
+++ b/README_es.md
@@ -581,6 +581,11 @@ Integra la API de DeepSeek en softwares populares. Accede a la [Plataforma Abier
         <td> <a href="https://github.com/titusTong/seekCodeCopilot/blob/main/README.md"> SeekCode Copilot </a> </td>
         <td> Asistente inteligente de codificación para VS Code que admite la configuración de modelos DeepSeek desplegados localmente. </td>
     </tr>
+    <tr>
+        <td> <img src="https://github.com/intellism/vscode-comment-translate/blob/master/doc/image/icon.png" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://github.com/intellism/vscode-comment-translate/blob/master/README.md"> Comment Translation </a> </td>
+        <td> Esta extensión ayuda a los desarrolladores a traducir anotaciones, cadenas, consejos de código, mensajes de error y nombres de variables en el Código. </td>
+    </tr>
 </table>
 
 ### Extensiones de Visual Studio

--- a/README_es.md
+++ b/README_es.md
@@ -326,6 +326,11 @@ Integra la API de DeepSeek en softwares populares. Accede a la [Plataforma Abier
         <td> <a href="https://pot-app.com/">Pot</a></td>
         <td> <a href="https://pot-app.com/">Pot</a> 🌈 Un software multiplataforma de traducción de palabras y OCR. </td>
     </tr>
+    <tr>
+        <td><img src="https://github.com/Byaidu/PDFMathTranslate/raw/main/docs/images/banner.png" alt="Icon" width="64" height="auto" /></td>
+        <td><a href="https://github.com/Byaidu/PDFMathTranslate">PDFMathTranslate</a></td>
+        <td>Esta extensión puede ayudar a los desarrolladores a traducir anotaciones, cadenas, consejos de código, mensajes de error y nombres de variables en el Código.</td>
+    </tr>
 </table>
 
 ### Marcos de agentes de IA

--- a/README_ja.md
+++ b/README_ja.md
@@ -235,6 +235,11 @@ DeepSeek API を人気のソフトウェアに統合します。API キーを取
         <td> <a href="https://popai.pro">PopAi</a> </td>
         <td>PopAiがDeepSeek R1を発表！PopAiで遅延のない、超高速なパフォーマンスをお楽しみください。 オンライン検索のオン/オフをシームレスに切り替え可能です。</td>
     </tr>
+    <tr>
+        <td> <img src="https://pot-app.com/logo/icon.svg" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://pot-app.com/">Pot</a></td>
+        <td> <a href="https://pot-app.com/">Pot</a> 🌈クロスプラットフォームの単語翻訳とOCRソフトウェア </td>
+    </tr>
 </table>
 
 ### AI エージェントフレームワーク

--- a/README_ja.md
+++ b/README_ja.md
@@ -240,6 +240,11 @@ DeepSeek API を人気のソフトウェアに統合します。API キーを取
         <td> <a href="https://pot-app.com/">Pot</a></td>
         <td> <a href="https://pot-app.com/">Pot</a> 🌈クロスプラットフォームの単語翻訳とOCRソフトウェア </td>
     </tr>
+    <tr>
+        <td><img src="https://github.com/Byaidu/PDFMathTranslate/raw/main/docs/images/banner.png" alt="Icon" width="64" height="auto" /></td>
+        <td><a href="https://github.com/Byaidu/PDFMathTranslate">PDFMathTranslate</a></td>
+        <td>この拡張プログラムは、開発者がコード内のコメント、文字列、コードヒント、エラー情報、変数名を翻訳するのに役立ちます。</td>
+    </tr>
 </table>
 
 ### AI エージェントフレームワーク

--- a/README_ja.md
+++ b/README_ja.md
@@ -245,6 +245,11 @@ DeepSeek API を人気のソフトウェアに統合します。API キーを取
         <td><a href="https://github.com/Byaidu/PDFMathTranslate">PDFMathTranslate</a></td>
         <td>この拡張プログラムは、開発者がコード内のコメント、文字列、コードヒント、エラー情報、変数名を翻訳するのに役立ちます。</td>
     </tr>
+    <tr>
+        <td><img src="https://github.com/Richasy/Bili.Copilot/raw/master/assets/StoreLogo.png" alt="Icon" width="64" height="auto" /></td>
+        <td><a href="https://github.com/Richasy/Bili.Copilot">Bili.Copilot</a></td>
+        <td>B局のサードパーティ製Windowsデスクトップクライアント、Windows App SDKを使用して構築されたネイティブアプリケーション。</td>
+    </tr>
 </table>
 
 ### AI エージェントフレームワーク

--- a/README_ja.md
+++ b/README_ja.md
@@ -453,6 +453,11 @@ DeepSeek API を人気のソフトウェアに統合します。API キーを取
         <td> <a href="https://github.com/titusTong/seekCodeCopilot/blob/main/README.md"> SeekCode Copilot </a> </td>
         <td> vscode インテリジェント コーディング アシスタントは、ローカルにデプロイされた DeepSeek モデルの構成をサポートします </td>
     </tr>
+    <tr>
+        <td> <img src="https://github.com/intellism/vscode-comment-translate/blob/master/doc/image/icon.png" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://github.com/intellism/vscode-comment-translate/blob/master/README_JA.md"> Comment Translation </a> </td>
+        <td> この拡張により、開発者はコード内のコメント、文字列、コードヒント、エラーメッセージ、変数名を翻訳できます。 </td>
+    </tr>
 </table>
 
 ### neovim 拡張機能

--- a/README_zh_tw.md
+++ b/README_zh_tw.md
@@ -331,6 +331,11 @@
         <td><a href="https://github.com/Byaidu/PDFMathTranslate">PDFMathTranslate</a></td>
         <td>這款擴展程式能够幫助開發者翻譯程式碼中的注釋、字串、程式碼提示、錯誤資訊以及變數名。</td>
     </tr>
+    <tr>
+        <td><img src="https://github.com/Richasy/Bili.Copilot/raw/master/assets/StoreLogo.png" alt="Icon" width="64" height="auto" /></td>
+        <td><a href="https://github.com/Richasy/Bili.Copilot">Bili.Copilot</a></td>
+        <td>B站協力廠商Windows案頭用戶端，使用Windows App SDK構建的原生應用。</td>
+    </tr>
 </table>
 
 ### AI 智慧體框架

--- a/README_zh_tw.md
+++ b/README_zh_tw.md
@@ -321,6 +321,11 @@
         <td> <a href="https://popai.pro">PopAi</a> </td>
         <td>PopAi 推出 DeepSeek R1！享受零延遲與超高速效能，輕鬆切換在線搜索開關。</td>
     </tr>
+    <tr>
+        <td> <img src="https://pot-app.com/logo/icon.svg" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://pot-app.com/">Pot</a></td>
+        <td> <a href="https://pot-app.com/">Pot</a> 🌈一個跨平臺的劃詞翻譯和OCR軟件 </td>
+    </tr>
 </table>
 
 ### AI 智慧體框架

--- a/README_zh_tw.md
+++ b/README_zh_tw.md
@@ -582,6 +582,11 @@
         <td> <a href="https://github.com/titusTong/seekCodeCopilot/blob/main/README.md"> SeekCode Copilot </a> </td>
         <td> 支援配置本地部署 DeepSeek 模型的 VS Code 智慧程式碼協助工具。 </td>
     </tr>
+    <tr>
+        <td> <img src="https://github.com/intellism/vscode-comment-translate/blob/master/doc/image/icon.png" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://github.com/intellism/vscode-comment-translate/blob/master/README_ZH.md"> Comment Translation </a> </td>
+        <td> 這款擴展程式能够幫助開發者翻譯程式碼中的注釋、字串、程式碼提示、錯誤資訊以及變數名。 </td>
+    </tr>
 </table>
 
 ### Visual Studio 擴充功能

--- a/README_zh_tw.md
+++ b/README_zh_tw.md
@@ -326,6 +326,11 @@
         <td> <a href="https://pot-app.com/">Pot</a></td>
         <td> <a href="https://pot-app.com/">Pot</a> 🌈一個跨平臺的劃詞翻譯和OCR軟件 </td>
     </tr>
+    <tr>
+        <td><img src="https://github.com/Byaidu/PDFMathTranslate/raw/main/docs/images/banner.png" alt="Icon" width="64" height="auto" /></td>
+        <td><a href="https://github.com/Byaidu/PDFMathTranslate">PDFMathTranslate</a></td>
+        <td>這款擴展程式能够幫助開發者翻譯程式碼中的注釋、字串、程式碼提示、錯誤資訊以及變數名。</td>
+    </tr>
 </table>
 
 ### AI 智慧體框架

--- a/README_zh_tw.md
+++ b/README_zh_tw.md
@@ -333,7 +333,7 @@
     </tr>
     <tr>
         <td><img src="https://github.com/Richasy/Bili.Copilot/raw/master/assets/StoreLogo.png" alt="Icon" width="64" height="auto" /></td>
-        <td><a href="https://github.com/Richasy/Bili.Copilot">Bili.Copilot</a></td>
+        <td><a href="https://github.com/Richasy/Bili.Copilot">嗶哩助理</a></td>
         <td>B站協力廠商Windows案頭用戶端，使用Windows App SDK構建的原生應用。</td>
     </tr>
 </table>


### PR DESCRIPTION
1. [Pot](https://github.com/pot-app/pot-desktop)是一个跨平台的划词翻译和OCR软件，可以调用DeepSeek API或Ollama中的DeepSeek翻译；
2. [Comment Translation](https://github.com/intellism/vscode-comment-translate)是vscode 注释翻译插件, 不干扰正常代码，方便快速阅读源码。可以接入DeepSeek API来进行翻译；
3. [PDFMathTranslate](https://github.com/Byaidu/PDFMathTranslate)是一款基于 AI 完整保留排版的 PDF 文档全文双语翻译工具，可以调用DeepSeek API对论文进行翻译；
4. [哔哩助理](https://github.com/Richasy/Bili.Copilot)是一款B站第三方 Windows 桌面客户端，使用 Windows App SDK 构建的原生应用。

希望能做一点贡献❤️🥺🎈