### PR TITLE
sets max_tokens avante.nvim/README.md

### DIFF
--- a/docs/avante.nvim/README.md
+++ b/docs/avante.nvim/README.md
@@ -32,6 +32,7 @@ return {
           api_key_name = "DEEPSEEK_API_KEY",
           endpoint = "https://api.deepseek.com",
           model = "deepseek-coder",
+          max_tokens = 8192,
         },
       },
     },


### PR DESCRIPTION
Otherwise an error message is returned in the response that the max_tokens must be in the range of `[1, 8192]`. Apparently this property has been raised over this limit in the openai config, which this setup inherits from.