### PR TITLE
Add Amoy Studio to Applications section

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,6 +557,11 @@ With these functionalities, the AI assistant can summarize key points within an 
         <td> <a href="https://github.com/songquanpeng/one-api">One API</a> </td>
         <td> One API is a LLM API management & key redistribution system, unifying multiple providers under a single API. Single binary, Docker-ready, with an English UI.</td>
     </tr>
+    <tr>
+        <td> <img src="https://amoy-tech.com/images/favicon.png" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://studio.amoy-tech.com">Amoy Studio</a> </td>
+        <td> Hong Kong-based AI productivity studio with multi-model support including DeepSeek (V3, R1), offering chat, content creation, professional translation, image generation, and visual recognition — no VPN required.</td>
+    </tr>  
 </table>
 
 <p style="text-align: right;"><a href="#table-of-contents">^ Back to Contents ^</a></p>

--- a/README_cn.md
+++ b/README_cn.md
@@ -471,6 +471,11 @@
         <td> <a href="https://www.aispire.info">AIspire</a> </td>
         <td> AIspire是一个辅助AI学术写作的全能助手，从学术问题解答、学术灵感发现、文献管理、辅助阅读到全自动化AI辅助写作，让你的科研更精准、更高效。 </td>
     </tr>
+   <tr>
+      <td> <img src="https://amoy-tech.com/images/favicon.png" alt="Icon" width="64" height="auto" /> </td>
+      <td> <a href="https://studio.amoy-tech.com">Amoy Studio</a> </td>
+      <td> 香港 AI 生产力工作室，支持多模型包括 DeepSeek（V3、R1），提供聊天、内容创作、专业翻译、图像生成及视觉识别 — 无需 VPN。</td>
+   </tr> 
 </table>
 
 <p style="text-align: right;"><a href="#目录">^ 返回目录 ^</a></p>

--- a/README_es.md
+++ b/README_es.md
@@ -432,6 +432,12 @@ Integra la API de DeepSeek en softwares populares. Accede a la [Plataforma Abier
         <td> <a href="https://turtlenoir.com/"> Turtle Noir </a> </td>
         <td> <a href="https://turtlenoir.com/"> Turtle Noir </a> Un juego de enigmas de pensamiento lateral tipo "Sopa de Tortuga" con un anfitrión de IA basado en DeepSeek, disponible para uno o varios jugadores. La IA modera la partida e interactúa con humor, guiando la deducción mediante respuestas de "Sí / No / Irrelevante". Ofrece una experiencia inmersiva con una fuerte atmósfera narrativa, gestión del ritmo y un sistema de pistas para evitar bloqueos. Integra búsqueda vectorial y DeepSeek para evitar la repetición de acertijos e incluye moderación de contenido. Ideal para entrenar la creatividad y como entretenimiento social en línea. </td>
     </tr>
+	<tr>
+	    <td> <img src="https://amoy-tech.com/images/favicon.png" alt="Icon" width="64" height="auto" /> </td>
+	    <td> <a href="https://studio.amoy-tech.com">Amoy Studio</a> </td>
+	    <td> Estudio de productividad AI con sede en Hong Kong con soporte multimodelo que incluye DeepSeek (V3, R1), ofrece chat, creación de contenido, traducción profesional, generación de imágenes y reconocimiento visual — sin necesidad de VPN.</td>
+	</tr>
+	
 </table>
 
 <p style="text-align: right;"><a href="#tabla-de-contenidos">^ Volver al índice ^</a></p>

--- a/README_ja.md
+++ b/README_ja.md
@@ -404,6 +404,11 @@ DeepSeek API を人気のソフトウェアに統合します。API キーを取
         <td> <a href="https://github.com/guyoung/AIMatrices/blob/main/README.md">AIMatrices</a> </td>
         <td>AIMatricesは、効率的で便利なaiアプリケーション開発体験を開発者に提供するために設計された、軽量、高性能、スケーラブルでオープンソースのaiアプリケーション迅速構築プラットフォームです。複数の高度なテクノロジとツールを統合することで、複雑なコードをゼロから作成することなく、ユーザーがaiアプリケーションを迅速に構築、展開、維持できるようになります。</td>
     </tr>
+	<tr>
+	    <td> <img src="https://amoy-tech.com/images/favicon.png" alt="Icon" width="64" height="auto" /> </td>
+	    <td> <a href="https://studio.amoy-tech.com">Amoy Studio</a> </td>
+	    <td> 香港の AI 生産性スタジオ。DeepSeek（V3、R1）を含むマルチモデル対応で、チャット、コンテンツ作成、プロ翻訳、画像生成、視覚認識を提供 — VPN不要。</td>
+	</tr>	
 </table>
 
 <p style="text-align: right;"><a href="#目次">^ 目次に戻る ^</a></p>

--- a/README_zh_tw.md
+++ b/README_zh_tw.md
@@ -470,6 +470,11 @@
         <td> <a href="https://haiguitang.net/"> Turtle Noir </a> </td>
         <td> <a href="https://haiguitang.net/"> Turtle Noir </a> 基於 DeepSeek 的 AI 主持人海龜湯 / 側向思維解謎產品，可單人或者多人遊玩。AI 進行控場與吐槽，圍繞「是 / 否 / 無關」的問答推進推理；提供沉浸式玩法（更強劇情氛圍與節奏引導）、引導提示與防卡關機制，同時結合向量檢索 + DeepSeek 進行題目去重，並提供內容審核能力。適合輕量腦洞訓練與在線陪玩。 </td>
     </tr>
+	<tr>
+	    <td> <img src="https://amoy-tech.com/images/favicon.png" alt="Icon" width="64" height="auto" /> </td>
+	    <td> <a href="https://studio.amoy-tech.com">Amoy Studio</a> </td>
+	    <td> 香港 AI 生產力工作室，支持多模型包括 DeepSeek（V3、R1），提供聊天、內容創作、專業翻譯、圖像生成及視覺辨識 — 無需 VPN。</td>
+	</tr>	
 </table>
 
 <p style="text-align: right;"><a href="#目錄">^ 返回目錄 ^</a></p>


### PR DESCRIPTION
I'd like to add **Amoy Studio** <a href="https://studio.amoy-tech.com" target="_blank">https://studio.amoy-tech.com</a> to the Applications list.

It's a Hong Kong-based AI productivity platform that integrates DeepSeek models (V3, R1 since Feb 2025), along with other major models. Key features include AI chat, content creation, professional translation, image generation, visual recognition, and it's optimized for Hong Kong users (no VPN required).

Added as a new row in the Applications Markdown table.

Thank you for reviewing and for maintaining this awesome list!