### PR TITLE
Add Agent Gateway to Providers section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1148,6 +1148,11 @@ The purpose is to build infrastructure in the field of large models, through the
         <td> <a href="https://docs.aimlapi.com/api-references/text-models-llm?utm_source=awesome-deepseek-integrations&utm_medium=github&utm_campaign=integration"> AI/ML API </a> </td>
         <td> AI/ML API gives users enterprise-grade access to 200+ models with just one API. This includes Deepseek R1 and V3, alongside closed and open-source models. All at 99% uptime and with 24/7 human support.</td>
     </tr>
+    <tr>
+        <td> <img src="./docs/agent-gateway/assets/logo.svg" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="docs/agent-gateway/README.md"> Agent Gateway </a> </td>
+        <td> Free, unified API gateway that routes LLM requests to DeepSeek, OpenAI, Anthropic, Google Gemini, Groq, and Together AI through a single OpenAI-compatible endpoint. Response caching, auto retries, 24+ models. No signup required.</td>
+    </tr>
 </table>
 
 <p style="text-align: right;"><a href="#table-of-contents">^ Back to Contents ^</a></p>

--- a/docs/agent-gateway/README.md
+++ b/docs/agent-gateway/README.md
@@ -1,0 +1,31 @@
+# Agent Gateway — LLM Router with DeepSeek Support
+
+[Agent Gateway](https://agent-gateway-kappa.vercel.app) is a free, unified API gateway that routes LLM requests to multiple providers including **DeepSeek**, OpenAI, Anthropic, Google Gemini, Groq, and Together AI through a single OpenAI-compatible endpoint.
+
+## DeepSeek Integration
+
+Agent Gateway supports DeepSeek models via the `/v1/chat/completions` endpoint:
+
+```bash
+curl -X POST "https://agent-gateway-kappa.vercel.app/v1/agent-llm/v1/chat/completions" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "deepseek/deepseek-chat",
+    "messages": [{"role": "user", "content": "Explain quantum computing in 3 sentences"}]
+  }'
+```
+
+## Features
+
+- **OpenAI-compatible endpoint** — drop-in replacement, works with any OpenAI SDK
+- **6 providers** — DeepSeek, OpenAI, Anthropic, Google Gemini, Groq, Together AI
+- **24+ models** — including DeepSeek Chat and DeepSeek Coder
+- **Response caching** — 5-minute TTL, reduces redundant API calls
+- **Auto retries** — automatic failover on provider errors
+- **No signup required** — free tier with 30 requests/minute
+
+## Links
+
+- [API Documentation](https://agent-gateway-kappa.vercel.app/docs)
+- [LLM Gateway Tutorial](https://api-catalog-three.vercel.app/blog/free-llm-api)
+- [All 39+ APIs](https://api-catalog-three.vercel.app/blog/best-free-apis-for-developers)

--- a/docs/agent-gateway/assets/logo.svg
+++ b/docs/agent-gateway/assets/logo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <rect width="64" height="64" rx="12" fill="#8b5cf6"/>
+  <text x="32" y="26" text-anchor="middle" fill="white" font-family="system-ui, sans-serif" font-size="10" font-weight="700">AGENT</text>
+  <text x="32" y="44" text-anchor="middle" fill="white" font-family="system-ui, sans-serif" font-size="10" font-weight="700">GATEWAY</text>
+</svg>


### PR DESCRIPTION
## Summary

Adds **Agent Gateway** to the Providers section — a free, unified API gateway that routes LLM requests to DeepSeek and 5 other providers through a single OpenAI-compatible endpoint.

## What it does

- Routes to **DeepSeek Chat** and **DeepSeek Coder** models via `/v1/chat/completions`
- OpenAI SDK compatible — works as a drop-in replacement
- Also supports OpenAI, Anthropic, Google Gemini, Groq, and Together AI
- Response caching (5-min TTL) and auto retries on provider errors
- Free tier: 30 requests/min, no signup required

## Files changed

- `README.md` — Added table row in Providers section
- `docs/agent-gateway/README.md` — Documentation with curl example
- `docs/agent-gateway/assets/logo.svg` — Logo icon