### PR TITLE
Add AllRatesToday × DeepSeek to Others

### DIFF
--- a/README.md
+++ b/README.md
@@ -1310,6 +1310,11 @@ The purpose is to build infrastructure in the field of large models, through the
         <td> <a href="https://github.com/informatico-madrid/blackwell-linux-infra-optimizer"> Blackwell Linux Infra Optimizer </a> </td>
         <td> Optimized vLLM stack for NVIDIA Blackwell (SM_120) and Linux Kernel 6.14. Achieving 59.0 t/s on DeepSeek-R1-32B using native FlashInfer backend. </td>
     </tr>
+    <tr>
+        <td style="font-size: 64px">&#128176;</td>
+        <td> <a href="https://github.com/cahthuranag/allratestoday-deepseek"> AllRatesToday &times; DeepSeek </a> </td>
+        <td> Plug real-time currency exchange rates into DeepSeek via function calling. Python package with agent wrapper and CLI; 5 tools for current rate, conversion, historical data (1d/7d/30d/1y), currency list, and FX news across 160+ currencies. Works with <code>deepseek-chat</code> and <code>deepseek-reasoner</code>. </td>
+    </tr>
 </table>
 
 <p style="text-align: right;"><a href="#table-of-contents">^ Back to Contents ^</a></p>


### PR DESCRIPTION
Adds a single entry to the **Others** section for a new DeepSeek integration.

## What it is

[`allratestoday-deepseek`](https://github.com/cahthuranag/allratestoday-deepseek) is a Python package that plugs real-time currency exchange rates into DeepSeek chat and agents via function calling.

- **Powered by DeepSeek** — uses `deepseek-chat` / `deepseek-reasoner` through DeepSeek's OpenAI-compatible Chat Completions API (`api.deepseek.com`).
- **5 tools** — current rate, currency conversion, historical rates (1d/7d/30d/1y), supported-currency list, and FX news.
- **160+ currencies** — mid-market rates from Reuters/Refinitiv.
- **Agent wrapper + CLI** — one-line `DeepSeekCurrencyAgent().ask("...")` or `allratestoday-deepseek --ask "..."`.
- **Public endpoints need no key** — users only need their existing `DEEPSEEK_API_KEY`.

## Why it belongs in the list

Real-time FX is a common gap when using DeepSeek for financial or cross-border assistance — the model hallucinates rates otherwise. This package fixes that with a drop-in tool-calling integration specifically targeted at DeepSeek.

## Example

```python
from allratestoday_deepseek import DeepSeekCurrencyAgent

with DeepSeekCurrencyAgent() as agent:
    print(agent.ask("Convert 2500 USD to EUR."))
# => "2500 USD ≈ 2307.13 EUR at the current mid-market rate of 0.9229."
```

Open to updating localized READMEs (`_cn`, `_es`, `_ja`, `_zh_tw`) if you'd like that in the same PR — I noticed they're a bit behind the main README so kept the patch to `README.md` only.