### PR TITLE
docs: add Reasonix — DeepSeek-native agent framework (TypeScript)

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,6 +590,11 @@ With these functionalities, the AI assistant can summarize key points within an 
         <td>A Rust framework for AI agent development, designed to build a highly composable, autonomous, and perpetually memorizing network of AI agents.</td>
     </tr>
     <tr>
+        <td> <img src="https://avatars.githubusercontent.com/esengine" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://github.com/deepseek-ai/awesome-deepseek-integration/blob/main/docs/reasonix/README.md">Reasonix</a> </td>
+        <td>A DeepSeek-native agent framework for TypeScript. Immutable-prefix Cache-First Loop (85–95% prefix cache hit), R1 Thought Harvesting into typed plan state, self-consistency branching, and a Tool-Call Repair layer (schema flatten, scavenge, truncation recovery, storm breaker). Ink-based TUI with live cache/cost panel. Measured 93.9% cost savings vs Claude Sonnet 4.6 on real multi-turn chat.</td>
+    </tr>
+    <tr>
         <td> <img src="https://www.dreams.fun/favicon.ico" alt="Icon" width="64" height="auto" /> </td>
         <td> <a href="https://github.com/daydreamsai/daydreams">Daydreams</a> </td>
         <td>Daydreams is a generative crosschain agent framework for executing anything onchain. Autonomous and easy to build on enabling the next generation of agents.</td>

--- a/README_cn.md
+++ b/README_cn.md
@@ -489,6 +489,11 @@
         <td> 一个专为 AI 智能体开发设计的 Rust 语言框架，致力于构建高度可组合、自主运行且具备永久记忆能力的 AI 智能体网络。 </td>
     </tr>
     <tr>
+        <td> <img src="https://avatars.githubusercontent.com/esengine" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://github.com/deepseek-ai/awesome-deepseek-integration/blob/main/docs/reasonix/README.md">Reasonix</a> </td>
+        <td> 专为 DeepSeek 深度优化的 TypeScript Agent 框架。通过不可变前缀的 Cache-First Loop 实现 85-95% 的 prefix 缓存命中率、R1 思考链结构化提取、自洽分支采样、以及完整的工具调用修复层（Schema 自动扁平化、tool call 捞取、JSON 截断修复、调用风暴熔断）。基于 Ink 的 TUI 实时显示缓存/成本面板。实测相比 Claude Sonnet 4.6 节省 93.9%。</td>
+    </tr>
+    <tr>
         <td> <img src="https://yomo.run/yomo-logo.png" alt="Icon" width="64" height="auto" /> </td>
         <td> <a href="https://github.com/deepseek-ai/awesome-deepseek-integration/blob/main/docs/yomo/README.md">YoMo</a> </td>
         <td> Stateful Serverless LLM Function Calling Framework with Strongly-typed Language Support </td>

--- a/docs/reasonix/README.md
+++ b/docs/reasonix/README.md
@@ -1,0 +1,152 @@
+# `Reasonix`
+
+> ⚡ A DeepSeek-native agent framework for TypeScript. Opinionated defaults squeeze every drop of value from DeepSeek's unique economic and behavioural profile.
+
+**Reasonix Source Code**: [https://github.com/esengine/reasonix](https://github.com/esengine/reasonix)
+
+**npm**: [https://www.npmjs.com/package/reasonix](https://www.npmjs.com/package/reasonix)
+
+Reasonix is built exclusively for DeepSeek (no generic multi-provider abstraction). Every design decision leans into a DeepSeek-specific property — automatic prefix caching, `reasoning_content` from R1, and the economic window opened by DeepSeek being ~20× cheaper than Claude.
+
+## 🚀 Quick Start
+
+```bash
+npm install -g reasonix
+reasonix chat
+```
+
+On first launch the TUI prompts for your DeepSeek API key and saves it to `~/.reasonix/config.json`. Sessions auto-persist — next launch resumes where you left off.
+
+## ✨ Core Design — Three Pillars
+
+### Pillar 1 — Cache-First Loop
+
+DeepSeek bills cached input tokens at ~10% of the miss rate, but the cache only hits when the byte prefix of the request is identical to the previous one. Most agent frameworks rebuild prompts each turn, so the cache rarely fires.
+
+Reasonix partitions the context into three regions with strict invariants:
+
+```
+┌─────────────────────────────────────────┐
+│ IMMUTABLE PREFIX                        │ ← fixed for the session
+│   system + tool_specs + few_shots       │   cache hit target
+├─────────────────────────────────────────┤
+│ APPEND-ONLY LOG                         │ ← grows monotonically
+│   [assistant₁][tool₁][assistant₂]...    │   preserves prior-turn prefix
+├─────────────────────────────────────────┤
+│ VOLATILE SCRATCH                        │ ← reset each turn
+│   R1 reasoning, transient plan state    │   never sent upstream
+└─────────────────────────────────────────┘
+```
+
+**Measured**: 85–95% prefix cache hit rate on real multi-turn sessions.
+
+### Pillar 2 — R1 Thought Harvesting
+
+R1's `reasoning_content` contains a plan, not just trivia to display. Reasonix pipes it through a cheap secondary V3 call in JSON mode and extracts a typed plan state:
+
+```typescript
+{
+  subgoals: string[],      // concrete intermediate objectives
+  hypotheses: string[],    // candidate approaches being weighed
+  uncertainties: string[], // facts flagged as unclear
+  rejectedPaths: string[]  // approaches the trace considered and abandoned
+}
+```
+
+The TUI renders this as a magenta block above the answer. The orchestrator can branch on it — e.g. sample more when `uncertainties.length > 2`.
+
+### Pillar 3 — Tool-Call Repair
+
+R1/V3 have known quirks: dropping arguments on deep/wide schemas, leaking tool calls into `<think>`, truncating JSON at `max_tokens`, call-storm loops. Reasonix ships four always-on repair passes:
+
+1. **scavenge** — regex + JSON parser sweeps `reasoning_content` for missed tool calls
+2. **flatten** — schemas with >10 leaf params or depth >2 auto-flattened to dot notation, args re-nested on dispatch
+3. **truncation recovery** — detect unbalanced JSON and close braces, trim trailing commas, fill dangling keys
+4. **storm breaker** — identical `(tool, args)` tuples within a sliding window are suppressed
+
+## 🎯 Bonus: Self-Consistency Branching
+
+Because DeepSeek is ~20× cheaper than Claude, running N=3 R1 samples per turn is still cheaper than a single Claude call. `/preset max` enables it. The default selector picks the sample with fewest flagged uncertainties (Occam tie-break on shorter answers).
+
+## 📊 Validated Numbers
+
+Measured against live DeepSeek API:
+
+| scenario | model | turns | cache hit | cost | Claude Sonnet 4.6 equivalent | savings |
+|---|---|---|---|---|---|---|
+| Chinese multi-turn chat | `deepseek-chat` | 5 | **85.2%** | $0.000923 | $0.015174 | **93.9%** |
+| Tool-use (calculator) | `deepseek-chat` | 2 | **94.9%** | $0.000142 | $0.003351 | **95.8%** |
+| R1 math + harvest | `deepseek-reasoner` | 1 | 72.7% | $0.006478 | $0.044484 | 85.4% |
+
+## 🛠️ Usage
+
+### CLI
+
+```bash
+reasonix chat                # auto-saves to session 'default'; resumes next time
+reasonix chat --session work # use a different named session
+reasonix chat --no-session   # ephemeral — nothing persisted
+reasonix run "ask anything"  # one-shot, streams to stdout
+```
+
+### Inside the TUI — slash commands
+
+```
+/preset fast|smart|max   one-tap config (fast is default)
+/model <id>              deepseek-chat or deepseek-reasoner
+/harvest [on|off]        Pillar 2 toggle
+/branch <N|off>          N parallel samples per turn (>=2)
+/sessions                list saved sessions
+/forget                  delete the current session
+/help                    full command list
+```
+
+### Library
+
+```typescript
+import { CacheFirstLoop, DeepSeekClient, ImmutablePrefix, ToolRegistry } from "reasonix";
+
+const client = new DeepSeekClient(); // reads DEEPSEEK_API_KEY
+const tools = new ToolRegistry();
+
+tools.register({
+  name: "add",
+  parameters: {
+    type: "object",
+    properties: { a: { type: "integer" }, b: { type: "integer" } },
+    required: ["a", "b"],
+  },
+  fn: ({ a, b }: { a: number; b: number }) => a + b,
+});
+
+const loop = new CacheFirstLoop({
+  client,
+  tools,
+  prefix: new ImmutablePrefix({
+    system: "You are a math helper.",
+    toolSpecs: tools.specs(),
+  }),
+  harvest: true,
+  branch: 3,
+  session: "my-session",
+});
+
+for await (const ev of loop.step("What is 17 + 25?")) {
+  if (ev.role === "assistant_final") console.log(ev.content);
+}
+```
+
+## 🎯 Explicit Non-Goals
+
+- Multi-agent orchestration (use LangGraph)
+- RAG / vector retrieval (use LlamaIndex)
+- Multi-provider abstraction (use LiteLLM)
+- Web UI / SaaS
+
+Reasonix does DeepSeek, deeply.
+
+## 🔗 Links
+
+- GitHub: [https://github.com/esengine/reasonix](https://github.com/esengine/reasonix)
+- npm: [https://www.npmjs.com/package/reasonix](https://www.npmjs.com/package/reasonix)
+- License: MIT


### PR DESCRIPTION
This PR adds **Reasonix** to the Agent Frameworks section.

## What is Reasonix

Reasonix is a TypeScript agent framework built exclusively for DeepSeek. Rather than treating DeepSeek as "OpenAI with a different base URL," every abstraction leans into DeepSeek-specific properties.

- Repository: https://github.com/esengine/reasonix
- npm: https://www.npmjs.com/package/reasonix
- License: MIT

## Three-pillar design

**Pillar 1 — Cache-First Loop**: immutable-prefix + append-only-log context layout so the byte prefix of every request stays identical. Measured at **85–95% prefix cache hit rate** on real multi-turn sessions (5-turn Chinese chat: $0.000923 total vs $0.015174 on Claude Sonnet 4.6 = **93.9% savings**).

**Pillar 2 — R1 Thought Harvesting**: parses `reasoning_content` into a typed plan state `{subgoals, hypotheses, uncertainties, rejectedPaths}` via a cheap V3 call in JSON mode. The orchestrator can branch on uncertainty count.

**Pillar 3 — Tool-Call Repair**: four always-on passes addressing known DeepSeek tool-use quirks — schema flatten for deep/wide schemas (>10 params or >2 levels), scavenge for tool calls leaked into `<think>`, truncation recovery for JSON cut by `max_tokens`, call-storm breaker for identical-arg repeat loops.

## Bonus: Self-Consistency Branching

Because DeepSeek is ~20× cheaper than Claude, running N=3 R1 samples per turn is still cheaper than a single Claude call. Opt-in via `reasonix chat --branch 3` or the `/preset max` slash command.

## What the PR changes

- Adds `docs/reasonix/README.md` (entry page linked from the table)
- Adds a `<tr>` row in the Agent Frameworks table of `README.md` (right after Anda)
- Adds a matching `<tr>` row in `README_cn.md`

Icon uses the project owner's GitHub avatar via `https://avatars.githubusercontent.com/esengine`.

Happy to iterate on placement, copy, or icon if you'd prefer a different look.