### PR TITLE
Add Roo Code to VS Code Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -948,6 +948,11 @@ The purpose is to build infrastructure in the field of large models, through the
         <td> Meet Cline, an AI assistant that can use your CLI aNd Editor. </td>
     </tr>
     <tr>
+        <td> <img src="https://raw.githubusercontent.com/RooCodeInc/Roo-Code/main/apps/web-roo-code/public/apple-touch-icon.png" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://github.com/RooCodeInc/Roo-Code"> Roo Code </a> </td>
+        <td> Roo Code gives you a whole dev team of AI agents in your code editor, with a dedicated DeepSeek provider including reasoning-mode support. </td>
+    </tr>
+    <tr>
         <td> <img src="https://raw.githubusercontent.com/Sitoi/ai-commit/refs/heads/main/images/logo.png?raw=true" alt="Icon" width="64" height="auto" /> </td>
         <td> <a href="https://github.com/Sitoi/ai-commit/blob/main/README.md"> AI Commit </a> </td>
         <td> Use AI to generate git commit messages in VS Code. </td>


### PR DESCRIPTION
Roo Code is an AI coding agent for VS Code with explicit first-class DeepSeek support — dedicated provider code including DeepSeek's thinking-mode handling, not just generic OpenAI-compatible config.

- Repo: https://github.com/RooCodeInc/Roo-Code (23k★, Apache-2.0, active)
- DeepSeek provider: [`src/api/providers/deepseek.ts`](https://github.com/RooCodeInc/Roo-Code/blob/main/src/api/providers/deepseek.ts) (handles DeepSeek-specific usage metrics and reasoning-content continuation for tool calls)
- Inserted immediately after Cline, since Roo Code descends from the Cline codebase. Follows the simple-form pattern used by existing VS Code Extensions rows.