### PR TITLE
Modify DeepSeek API configuration in README_cn

### DIFF
--- a/docs/continue/README_cn.md
+++ b/docs/continue/README_cn.md
@@ -22,7 +22,7 @@ schema: v1
 models:
   - name: DeepSeek
     provider: deepseek
-    model: deepseek-chat
+    model: deepseek-v4-flash
     apiKey: YOUR_DEEPSEEK_API_KEY
     apiBase: https://api.deepseek.com/beta
     roles:
@@ -31,10 +31,10 @@ models:
       - apply
       - summarize
       - autocomplete
-    contextLength: 128000
+    contextLength: 1000000
     defaultCompletionOptions:
       temperature: 0.0
-      maxTokens: 256
+      maxTokens: 384
 context:
   - provider: code
   - provider: docs


### PR DESCRIPTION
model: deepseek-chat -> deepseek-v4-flash
contextLenght: 128000 -> 1000000
maxTokens: 256 -> 384