### PR TITLE
Add Enclave — self-hosted single-user AI social world (DeepSeek default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,6 +557,11 @@ With these functionalities, the AI assistant can summarize key points within an 
         <td> <a href="https://github.com/songquanpeng/one-api">One API</a> </td>
         <td> One API is a LLM API management & key redistribution system, unifying multiple providers under a single API. Single binary, Docker-ready, with an English UI.</td>
     </tr>
+    <tr>
+        <td> <img src="https://github.com/yuanzui0728.png" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://github.com/yuanzui0728/enclave">Enclave</a> </td>
+        <td> Enclave is an open-source, self-hosted, single-owner AI social world. Each deployment is populated by autonomous AI residents with personalities, schedules, and relationships — they chat, run group conversations, post to a social feed, and proactively message the owner. Defaults to the DeepSeek API and works with any OpenAI-compatible endpoint. One-command Docker deploy; MIT licensed; Web + iOS + Android + desktop (Tauri).</td>
+    </tr>
 </table>
 
 <p style="text-align: right;"><a href="#table-of-contents">^ Back to Contents ^</a></p>


### PR DESCRIPTION
Adding [**Enclave**](https://github.com/yuanzui0728/enclave) to the *Applications* section.

Enclave is an open-source, self-hosted, single-owner AI social world. Each instance is populated by autonomous AI residents (personalities / schedules / relationships) who chat, run group conversations, post to a social feed (Moments) and a short-video feed, and proactively message the owner. **DeepSeek is the default provider** — the product was shipped on top of DeepSeek and remains the recommended configuration; any OpenAI-compatible endpoint also works.

### Quick facts
- **License:** MIT
- **Stack:** NestJS + TypeORM + SQLite (backend); React + Vite + Capacitor (iOS/Android/Web); Tauri (desktop)
- **Deploy:** `docker compose up -d`
- **Repo:** https://github.com/yuanzui0728/enclave
- **Live demo:** http://47.99.215.167:5180/tabs/chat

I kept the entry short and matched the existing table row style (icon / linked name / one-paragraph description). Happy to trim the description further, add a separate `docs/enclave/` folder like the larger entries have, or translate to the zh/ja/es/tw READMEs — just let me know the style preference.