### PR TITLE
docs: add FuturMix to Providers section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1148,6 +1148,11 @@ The purpose is to build infrastructure in the field of large models, through the
         <td> <a href="https://docs.aimlapi.com/api-references/text-models-llm?utm_source=awesome-deepseek-integrations&utm_medium=github&utm_campaign=integration"> AI/ML API </a> </td>
         <td> AI/ML API gives users enterprise-grade access to 200+ models with just one API. This includes Deepseek R1 and V3, alongside closed and open-source models. All at 99% uptime and with 24/7 human support.</td>
     </tr>
+    <tr>
+        <td> <img src="https://futurmix.ai/logo.svg" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://futurmix.ai"> FuturMix </a> </td>
+        <td> FuturMix is a unified AI gateway that provides access to DeepSeek and 22+ models through a single OpenAI-compatible API endpoint. Features 99.99% SLA, automatic failover, and cost-effective pricing.</td>
+    </tr>
 </table>
 
 <p style="text-align: right;"><a href="#table-of-contents">^ Back to Contents ^</a></p>

--- a/README_zh_tw.md
+++ b/README_zh_tw.md
@@ -992,6 +992,11 @@
         <td> <a href="https://docs.aimlapi.com/api-references/text-models-llm?utm_source=awesome-deepseek-integrations&utm_medium=github&utm_campaign=integration"> AI/ML API </a> </td>
         <td> AI/ML API 讓使用者只需透過一個 API，就能以企業級的方式存取 200 種以上的模型。 這包括 Deepseek R1 和 V3，以及封閉和開源模型。 所有服務的正常運行時間均為 99%，並提供 24/7 全天候的人力支援。</td>
     </tr>
+    <tr>
+        <td> <img src="https://futurmix.ai/logo.svg" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://futurmix.ai"> FuturMix </a> </td>
+        <td> FuturMix 是一個統一的 AI 閘道器，透過單一 OpenAI 相容 API 端點提供 DeepSeek 及 22+ 種模型的存取。具備 99.99% SLA、自動故障轉移及高性價比定價。</td>
+    </tr>
 </table>
 
 <p style="text-align: right;"><a href="#目錄">^ 返回目錄 ^</a></p>


### PR DESCRIPTION
## Summary

Add [FuturMix](https://futurmix.ai) to the **Providers** section in the English and Traditional Chinese READMEs.

FuturMix is an enterprise AI agent platform that provides access to DeepSeek (R1, V3) and 22+ other models . Key features:

- **OpenAI-compatible API** — compatible, works with any OpenAI SDK
- **99.99% SLA** with automatic failover
- **22+ models** including DeepSeek, Claude, GPT, Gemini
- Cost-effective pricing

## Changes

- `README.md` — added FuturMix entry in Providers table
- `README_zh_tw.md` — added FuturMix entry in 供應商 table (Traditional Chinese)

The other localized READMEs (CN, JA, ES) do not currently have a Providers section, so no changes were needed there.