### PR TITLE
Add open-multi-agent to AI Agent frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -620,6 +620,11 @@ With these functionalities, the AI assistant can summarize key points within an 
         <td> <a href="https://github.com/guyoung/AIMatrices/blob/main/README.md">AIMatrices</a> </td>
         <td>AIMatrices is a lightweight, high-performance, scalable, and open source AI application rapid building platform designed to provide developers with an efficient and convenient AI application development experience. It integrates multiple advanced technologies and tools to help users quickly build, deploy, and maintain AI applications without having to write complex code from scratch.</td>
     </tr>
+    <tr>
+        <td width=80> <img src="https://raw.githubusercontent.com/JackChen-me/open-multi-agent/main/.github/brand/logo-mark-light.svg" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://github.com/deepseek-ai/awesome-deepseek-integration/blob/main/docs/open-multi-agent/README.md">open-multi-agent</a> </td>
+        <td> A TypeScript-native multi-agent orchestration framework with a goal-driven Coordinator that turns a single goal into a parallel task DAG. Ships with shared memory, MCP support, and live tracing. DeepSeek is a first-class provider: both <code>deepseek-chat</code> (V3) and <code>deepseek-reasoner</code> (thinking mode) work out of the box via a dedicated adapter. </td>
+    </tr>
 </table>
 
 ### RAG frameworks

--- a/README_cn.md
+++ b/README_cn.md
@@ -529,6 +529,11 @@
         <td> <a href="https://github.com/Tencent/Youtu-agent/"> Youtu-Agent </a> </td>
         <td> <a href="https://github.com/Tencent/Youtu-agent/"> Youtu-Agent </a> 是一个灵活、高性能的框架，用于构建、运行和评估自主智能体。除了在基准测试中名列前茅，该框架还提供了强大的智能体能力，采用开源模型即可实现例如数据分析、文件处理、深度研究等功能。 </td>
     </tr>
+    <tr>
+        <td width=80> <img src="https://raw.githubusercontent.com/JackChen-me/open-multi-agent/main/.github/brand/logo-mark-light.svg" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://github.com/deepseek-ai/awesome-deepseek-integration/blob/main/docs/open-multi-agent/README_cn.md">open-multi-agent</a> </td>
+        <td> 一个 TypeScript 原生的多智能体编排框架。其目标驱动的 Coordinator 会自动将单个目标拆解为并行任务 DAG，内置共享记忆、MCP 支持和实时追踪。DeepSeek 作为一等公民提供商接入，<code>deepseek-chat</code>（V3）与 <code>deepseek-reasoner</code>（思考模式）均可通过专用 adapter 开箱即用。 </td>
+    </tr>
 </table>
 
 <p style="text-align: right;"><a href="#目录">^ 返回目录 ^</a></p>

--- a/docs/open-multi-agent/README.md
+++ b/docs/open-multi-agent/README.md
@@ -1,0 +1,68 @@
+# [open-multi-agent](https://github.com/JackChen-me/open-multi-agent)
+
+<img src="https://raw.githubusercontent.com/JackChen-me/open-multi-agent/main/.github/brand/logo-mark-light.svg" alt="open-multi-agent" width="120" />
+
+`open-multi-agent` is a TypeScript-native framework for building multi-agent systems. Its **goal-driven Coordinator** automatically decomposes a single goal into a parallel task DAG, dispatches tasks to the best-fit agents, and synthesizes a final answer. DeepSeek is supported as a first-class LLM provider through a dedicated adapter.
+
+## Key Features
+
+- **Goal → DAG, automatically.** A coordinator agent decomposes a goal into a typed task graph; independent tasks run in parallel, dependent tasks wait.
+- **First-class DeepSeek support.** `deepseek-chat` (DeepSeek-V3) for fast coding and tool use, `deepseek-reasoner` for thinking-mode reasoning.
+- **Shared memory & MCP.** Namespaced shared memory across agents; lazy-loaded Model Context Protocol integration via the `open-multi-agent/mcp` subpath.
+- **Built-in tools.** `bash`, `file_read`, `file_write`, `file_edit`, `grep`, `glob`, plus opt-in `delegate_to_agent` for sub-agent calls.
+- **Three runtime dependencies.** `@anthropic-ai/sdk`, `openai`, `zod`. Other providers and MCP load lazily so you only pay for what you use.
+
+## Integrate with the DeepSeek API
+
+Install:
+
+```bash
+npm install open-multi-agent
+export DEEPSEEK_API_KEY=sk-...
+```
+
+### Single agent
+
+```typescript
+import { OpenMultiAgent } from 'open-multi-agent'
+
+const oma = new OpenMultiAgent({
+  defaultProvider: 'deepseek',
+  defaultModel: 'deepseek-chat', // or 'deepseek-reasoner' for thinking mode
+})
+
+const result = await oma.runAgent(
+  {
+    name: 'researcher',
+    systemPrompt: 'You are a careful research assistant.',
+  },
+  'Summarize the key ideas of DeepSeek-V3 in 5 bullets.'
+)
+
+console.log(result.output)
+```
+
+### Multi-agent team (goal-driven)
+
+```typescript
+const team = oma.createTeam('api-team', {
+  name: 'api-team',
+  sharedMemory: true,
+  agents: [
+    { name: 'architect', provider: 'deepseek', model: 'deepseek-reasoner', systemPrompt: 'You design clear API contracts.' },
+    { name: 'developer', provider: 'deepseek', model: 'deepseek-chat',     systemPrompt: 'You implement what the architect specifies.', tools: ['bash', 'file_write', 'file_edit'] },
+    { name: 'reviewer',  provider: 'deepseek', model: 'deepseek-chat',     systemPrompt: 'You review code for correctness and clarity.', tools: ['file_read', 'grep'] },
+  ],
+})
+
+const teamResult = await oma.runTeam(team, 'Build a minimal Express REST API with /health and /users endpoints.')
+console.log(teamResult.success, teamResult.totalTokenUsage)
+```
+
+A complete runnable example lives at [`examples/providers/deepseek.ts`](https://github.com/JackChen-me/open-multi-agent/blob/main/examples/providers/deepseek.ts).
+
+## Resources
+
+- GitHub: https://github.com/JackChen-me/open-multi-agent
+- Examples: https://github.com/JackChen-me/open-multi-agent/tree/main/examples
+- CLI docs: https://github.com/JackChen-me/open-multi-agent/blob/main/docs/cli.md

--- a/docs/open-multi-agent/README_cn.md
+++ b/docs/open-multi-agent/README_cn.md
@@ -1,0 +1,68 @@
+# [open-multi-agent](https://github.com/JackChen-me/open-multi-agent)
+
+<img src="https://raw.githubusercontent.com/JackChen-me/open-multi-agent/main/.github/brand/logo-mark-light.svg" alt="open-multi-agent" width="120" />
+
+`open-multi-agent` 是一个 TypeScript 原生的多智能体系统构建框架。其**目标驱动的 Coordinator** 会自动将一个目标拆解为并行任务 DAG、分配给最合适的 agent，并综合各任务结果给出最终输出。DeepSeek 通过专用 adapter 作为一等公民 LLM 提供商接入。
+
+## 核心特性
+
+- **目标 → DAG，自动化**：Coordinator agent 将目标拆解为带类型的任务图；无依赖的任务并行执行，有依赖的任务自动等待。
+- **DeepSeek 一等公民支持**：`deepseek-chat`（DeepSeek-V3）适合快速编码与工具调用，`deepseek-reasoner` 适合思考模式推理。
+- **共享记忆 & MCP**：跨 agent 的命名空间共享记忆；通过 `open-multi-agent/mcp` 子路径懒加载 Model Context Protocol 集成。
+- **内置工具**：`bash`、`file_read`、`file_write`、`file_edit`、`grep`、`glob`，以及可选的 `delegate_to_agent` 用于子 agent 调用。
+- **三个运行时依赖**：`@anthropic-ai/sdk`、`openai`、`zod`。其他 provider 与 MCP 均懒加载，只为实际使用的能力付费。
+
+## 接入 DeepSeek API
+
+安装：
+
+```bash
+npm install open-multi-agent
+export DEEPSEEK_API_KEY=sk-...
+```
+
+### 单 agent
+
+```typescript
+import { OpenMultiAgent } from 'open-multi-agent'
+
+const oma = new OpenMultiAgent({
+  defaultProvider: 'deepseek',
+  defaultModel: 'deepseek-chat', // 或使用 'deepseek-reasoner' 切换到思考模式
+})
+
+const result = await oma.runAgent(
+  {
+    name: 'researcher',
+    systemPrompt: '你是一个严谨的研究助理。',
+  },
+  '用 5 个 bullet 概括 DeepSeek-V3 的核心思路。'
+)
+
+console.log(result.output)
+```
+
+### 多 agent 团队（目标驱动）
+
+```typescript
+const team = oma.createTeam('api-team', {
+  name: 'api-team',
+  sharedMemory: true,
+  agents: [
+    { name: 'architect', provider: 'deepseek', model: 'deepseek-reasoner', systemPrompt: '你负责设计清晰的 API 契约。' },
+    { name: 'developer', provider: 'deepseek', model: 'deepseek-chat',     systemPrompt: '你按 architect 的设计实现代码。', tools: ['bash', 'file_write', 'file_edit'] },
+    { name: 'reviewer',  provider: 'deepseek', model: 'deepseek-chat',     systemPrompt: '你审查代码的正确性与清晰度。', tools: ['file_read', 'grep'] },
+  ],
+})
+
+const teamResult = await oma.runTeam(team, '搭建一个最小 Express REST API，包含 /health 与 /users 接口。')
+console.log(teamResult.success, teamResult.totalTokenUsage)
+```
+
+完整可运行示例：[`examples/providers/deepseek.ts`](https://github.com/JackChen-me/open-multi-agent/blob/main/examples/providers/deepseek.ts)。
+
+## 相关资源
+
+- GitHub：https://github.com/JackChen-me/open-multi-agent
+- 示例集合：https://github.com/JackChen-me/open-multi-agent/tree/main/examples
+- CLI 文档：https://github.com/JackChen-me/open-multi-agent/blob/main/docs/cli.md


### PR DESCRIPTION
This PR adds open-multi-agent to the **AI Agent frameworks** section.

open-multi-agent is a TypeScript-native multi-agent orchestration framework. Its goal-driven Coordinator turns a single goal into a parallel task DAG, with built-in shared memory, MCP support, and live tracing. DeepSeek is supported as a first-class provider via a dedicated adapter; both `deepseek-chat` (V3) and `deepseek-reasoner` (thinking mode) work out of the box.

- Repo: https://github.com/JackChen-me/open-multi-agent
- DeepSeek runnable example: [`examples/providers/deepseek.ts`](https://github.com/JackChen-me/open-multi-agent/blob/main/examples/providers/deepseek.ts)

Following the existing structure, new entries under `docs/open-multi-agent/` (English + 中文) are also added, and both `README.md` and `README_cn.md` index tables are updated.