### PR TITLE
Add proxy functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -990,6 +990,12 @@ The purpose is to build infrastructure in the field of large models, through the
 
 <table>
     <tr>
+        <td> </td>
+        <td> <a href="https://github.com/iqmeta/vs2026-copilot-deepseek-v4"> C# DeepSeek Github Copilot Proxy for Visual Studio 2026 Ollama Provider </a> </td>
+        <td> A high-performance, ultra-low-overhead HTTP proxy that connects GitHub Copilot and Ollama clients to the DeepSeek API. Built with .NET 10 and ASP.NET Core minimal APIs for maximum throughput and minimal allocations.
+</td>
+    </tr>
+    <tr>
         <td> <img src="https://merryyellow.gallerycdn.vsassets.io/extensions/merryyellow/comment2gpt/2.0.5/1739475434185/Microsoft.VisualStudio.Services.Icons.Default" alt="Icon" width="64" height="auto" /> </td>
         <td> <a href="https://marketplace.visualstudio.com/items?itemName=MerryYellow.Comment2GPT"> Comment2GPT </a> </td>
         <td> Use OpenAI ChatGPT, Google Gemini, Anthropic Claude, DeepSeek and Ollama through your comments </td>


### PR DESCRIPTION
This pull request adds a new entry to the Visual Studio Extensions section in the `README.md`, highlighting a C# DeepSeek GitHub Copilot Proxy for Visual Studio 2026. The update provides information and a link to the new project, which serves as a high-performance HTTP proxy connecting Copilot and Ollama clients to the DeepSeek API.

Documentation update:

* Added a new row to the Visual Studio Extensions table in `README.md` describing the C# DeepSeek GitHub Copilot Proxy for Visual Studio 2026 Ollama Provider, including a project link and a brief description of its features and technology stack.