### PR TITLE
docs: update oai-compatible-copilot with DeepSeek V4 models

### DIFF
--- a/docs/oai-compatible-copilot/README.md
+++ b/docs/oai-compatible-copilot/README.md
@@ -33,16 +33,18 @@ An open-source VS Code extension to use openai compatible inference providers in
 "oaicopilot.baseUrl": "https://api.deepseek.com/v1",
 "oaicopilot.models": [
   {
-      "id": "deepseek-chat",
+      "id": "deepseek-v4-flash",
       "owned_by": "deepseek",
-      "context_length": 128000,
-      "max_tokens": 8000
+      "context_length": 1000000,
+      "max_tokens": 384000,
+      "include_reasoning_in_request": true
   },
   {
-      "id": "deepseek-reasoner",
+      "id": "deepseek-v4-pro",
       "owned_by": "deepseek",
-      "context_length": 128000,
-      "max_tokens": 16000
+      "context_length": 1000000,
+      "max_tokens": 384000,
+      "include_reasoning_in_request": true
   }
 ]
 ```

--- a/docs/oai-compatible-copilot/README_cn.md
+++ b/docs/oai-compatible-copilot/README_cn.md
@@ -33,16 +33,18 @@
 "oaicopilot.baseUrl": "https://api.deepseek.com/v1",
 "oaicopilot.models": [
   {
-      "id": "deepseek-chat",
+      "id": "deepseek-v4-flash",
       "owned_by": "deepseek",
-      "context_length": 128000,
-      "max_tokens": 8000
+      "context_length": 1000000,
+      "max_tokens": 384000,
+      "include_reasoning_in_request": true
   },
   {
-      "id": "deepseek-reasoner",
+      "id": "deepseek-v4-pro",
       "owned_by": "deepseek",
-      "context_length": 128000,
-      "max_tokens": 16000
+      "context_length": 1000000,
+      "max_tokens": 384000,
+      "include_reasoning_in_request": true
   }
 ]
 ```


### PR DESCRIPTION
Update documentation to use DeepSeek V4 models (deepseek-v4-flash, deepseek-v4-pro) with correct context lengths and reasoning support.

Fixes #599