### PR TITLE
Add: DeepSeekWidget — Android home screen widget for DeepSeek

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,11 @@ With these functionalities, the AI assistant can summarize key points within an 
         <td><a href="./docs/xhai_browser/README.md">xhai Browser</a></td>
         <td>xhai Browser is an Android desktop management & AI browser, DeepSeek is the default AI dialog engine.It has the ultimate performance (0.2 seconds to start), slim size (apk 3M), no ads, ultra-fast ad blocking, multi-screen classification, screen navigation, multi-search box, a box multiple search!</td>
     </tr>
+  <tr>
+        <<td style="font-size: 64 px">🐳</td>
+        <td><a href="https://github.com/rajit2004/DeepSeekWidget">DeepSeekWidget</a></td>
+        <td>An open-source Android home screen widget for one-tap access to DeepSeek. Tap to open DeepSeek instantly, or use the voice button to speak your query — no need to unlock the app. Built with Kotlin, zero background services, Material You design. Supports Android 8.0+.</td>
+    </tr>
     <tr>
         <td><img src="https://i.imgur.com/FkbmMVG.png" alt="Icon" width="64" height="auto" /></td>
         <td><a href="https://intellibar.app/">IntelliBar</a></td>

--- a/README.md
+++ b/README.md
@@ -112,11 +112,11 @@ With these functionalities, the AI assistant can summarize key points within an 
         <td><a href="./docs/xhai_browser/README.md">xhai Browser</a></td>
         <td>xhai Browser is an Android desktop management & AI browser, DeepSeek is the default AI dialog engine.It has the ultimate performance (0.2 seconds to start), slim size (apk 3M), no ads, ultra-fast ad blocking, multi-screen classification, screen navigation, multi-search box, a box multiple search!</td>
     </tr>
-  <tr>
-        <<td style="font-size: 64 px">🐳</td>
-        <td><a href="https://github.com/rajit2004/DeepSeekWidget">DeepSeekWidget</a></td>
-        <td>An open-source Android home screen widget for one-tap access to DeepSeek. Tap to open DeepSeek instantly, or use the voice button to speak your query — no need to unlock the app. Built with Kotlin, zero background services, Material You design. Supports Android 8.0+.</td>
-    </tr>
+ <tr>
+    <td><img src="https://raw.githubusercontent.com/rajit2004/DeepSeekWidget/main/screenshots/deepseek.jpg" alt="DeepSeekWidget" width="64" height="auto" /></td>
+    <td><a href="https://github.com/rajit2004/DeepSeekWidget">DeepSeekWidget</a></td>
+    <td>Android home screen widget for one‑tap access to DeepSeek chat with voice input support.</td>
+</tr>
     <tr>
         <td><img src="https://i.imgur.com/FkbmMVG.png" alt="Icon" width="64" height="auto" /></td>
         <td><a href="https://intellibar.app/">IntelliBar</a></td>


### PR DESCRIPTION
## Summary

The DeepSeek Android app currently has no home screen widget support.
An Android widget would allow users to access DeepSeek with a single tap
or voice query directly from their home screen — without opening the app.

## Why it matters

- Millions of Android users rely on widgets for quick access to tools
- Competing AI apps (ChatGPT, Gemini) don't have this either — it would be a differentiator
- Reduces friction significantly for daily AI usage

## Reference Implementation

I built an open-source proof-of-concept to demonstrate this is feasible:

👉 https://github.com/rajit2004/DeepSeekWidget

It includes:

- One-tap widget to open DeepSeek chat
- Voice input button with runtime microphone permission handling
- Camera button to capture and share images directly to DeepSeek
- Graceful fallback to DeepSeek web chat if the app is not installed
- Material You design, Android 8.0+ support
- Debug APK available: v1.1 release (bug fixes + compileSdk 35)

Happy to contribute or collaborate if the team decides to pursue this officially.