### PR TITLE
Add OpenSeek - TUI coding agent with native DeepSeek V4 + cache-aware cost tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1102,6 +1102,11 @@ The purpose is to build infrastructure in the field of large models, through the
         <td> <a href="docs/wusigram/README.md"> 无思微程序 </a> </td>
         <td>A mobile AI code writing and running tool. DeepSeek Programming Companion</td>
     </tr>
+    <tr>
+        <td> <img src="https://avatars.githubusercontent.com/u/3425350?v=4" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://github.com/LichAmnesia/openseek"> OpenSeek </a> </td>
+        <td>Open-source TUI coding agent (TypeScript / Bun) with native DeepSeek V4 support, real-time prefix cache hit rate display in cost meter, real MCP client + server, LSP feedback loop (tsserver / rust-analyzer / pyright / gopls / clangd), and 27 providers. Defaults to DeepSeek V4. Apache-2.0, <code>npm install -g openseek</code>.</td>
+    </tr>
 </table>
 
 <p style="text-align: right;"><a href="#table-of-contents">^ Back to Contents ^</a></p>

--- a/README_cn.md
+++ b/README_cn.md
@@ -901,6 +901,11 @@
         <td> <a href="docs/wusigram/README_cn.md"> 无思微程序 </a> </td>
         <td> 移动端AI编程和运行工具，DeepSeek编程搭档 </td>
     </tr>
+    <tr>
+        <td> <img src="https://avatars.githubusercontent.com/u/3425350?v=4" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://github.com/LichAmnesia/openseek"> OpenSeek </a> </td>
+        <td> 开源 TUI 编程 Agent（TypeScript / Bun），原生支持 DeepSeek V4，实时显示 prefix cache 命中率，真 MCP 客户端 + LSP feedback loop（tsserver / rust-analyzer / pyright / gopls / clangd），27 个 provider，默认走 DeepSeek V4。Apache-2.0，<code>npm install -g openseek</code>。</td>
+    </tr>
 </table>
 
 <p style="text-align: right;"><a href="#目录">^ 返回目录 ^</a></p>


### PR DESCRIPTION
Adds [OpenSeek](https://github.com/LichAmnesia/openseek) to the **Native AI Code Editor** section in both English (README.md) and Chinese (README_cn.md).

## What is OpenSeek

Open-source TUI coding agent built in TypeScript / Bun monorepo. v1.0 shipped with 56/56 SPEC gates closed and 954 tests passing. Apache-2.0 licensed. Published to npm as `openseek`.

## Why it fits this list

- **Native DeepSeek V4 first-class support** — not just "supports any OpenAI-compat endpoint", but specifically optimizes for DeepSeek's prefix cache (cache-aware prompt assembly), \`reasoning_content\` replay for V4 thinking mode, and real-time cache hit rate display in the terminal cost meter.
- **27 providers total** including OpenAI-compat (19), Anthropic (4), Google (2), ollama, and custom — DeepSeek V4 is the default backend.
- **Real MCP client + server** with stdio + SSE + websocket transports (handrolled JSON-RPC 2.0).
- **LSP feedback loop** across 5 languages: tsserver / rust-analyzer / pyright / gopls / clangd. Boosts model first-try fix rate from ~30% to ~80% on DeepSeek V4.
- **Plan / Agent / YOLO modes** with git worktree isolation for safe autonomous runs.
- 52 tools + 108 slash commands.

## Install

\`\`\`
curl -fsSL https://bun.sh/install | bash
npm install -g openseek
openseek
\`\`\`

## Notes

- Entry appended to the existing Native AI Code Editor section (Cursor / WindSurf / 无思微程序) — fits the "AI Code Editor" framing (TUI form factor instead of GUI).
- Same entry added in EN + ZH READMEs for consistency.
- Other language READMEs (ja / es / zh_tw) not updated to keep PR scope minimal; happy to extend if desired.

Repo: https://github.com/LichAmnesia/openseek · Docs: https://openseek.dev · npm: https://www.npmjs.com/package/openseek