### PR TITLE
Add Permafrost (cache-aligning proxy + Claude Code plugin) to Others

### DIFF
--- a/README.md
+++ b/README.md
@@ -1310,6 +1310,11 @@ The purpose is to build infrastructure in the field of large models, through the
         <td> <a href="https://github.com/informatico-madrid/blackwell-linux-infra-optimizer"> Blackwell Linux Infra Optimizer </a> </td>
         <td> Optimized vLLM stack for NVIDIA Blackwell (SM_120) and Linux Kernel 6.14. Achieving 59.0 t/s on DeepSeek-R1-32B using native FlashInfer backend. </td>
     </tr>
+    <tr>
+        <td style="font-size: 64px">❄️</td>
+        <td> <a href="docs/permafrost/README.md"> Permafrost </a> </td>
+        <td> A cache-aligning proxy + Claude Code plugin that freezes the prompt prefix so DeepSeek's automatic context cache always hits — measured 64% cost reduction on real Claude Code traffic via the Anthropic-compatible endpoint. </td>
+    </tr>
 </table>
 
 <p style="text-align: right;"><a href="#table-of-contents">^ Back to Contents ^</a></p>

--- a/README_cn.md
+++ b/README_cn.md
@@ -1005,6 +1005,11 @@
         <td> <a href="https://github.com/sally-suite/open-office-copilot">Open Office Copilot</a> </td>
         <td> Open Office Copilot 是一个开源的 Office 助手，支持 Microsoft Office 和 Google Workspace，基于 AI-Agent。它可以帮助你在 Word 中写作、在 PowerPoint 中生成幻灯片、在 Excel 中分析数据、在 Outlook 里帮你生成邮件等，现在已经集成了 DeepSeek。</td>
     </tr>
+    <tr>
+        <td style="font-size: 64px">❄️</td>
+        <td> <a href="docs/permafrost/README_cn.md"> Permafrost </a> </td>
+        <td> 缓存对齐代理 + Claude Code 插件：冻结提示词前缀，让 DeepSeek 自动上下文缓存每轮命中，经 Anthropic 兼容端点在真实 Claude Code 流量上实测节省 64% 成本。 </td>
+    </tr>
 </table>
 
 <p style="text-align: right;"><a href="#目录">^ 返回目录 ^</a></p>

--- a/docs/permafrost/README.md
+++ b/docs/permafrost/README.md
@@ -1,0 +1,49 @@
+<div style="font-size: 64px">❄️</div>
+
+# [Permafrost](https://github.com/jianzhichun/permafrost)
+
+Freeze Claude Code's prompt prefix so DeepSeek's automatic context cache always
+hits. Permafrost is a zero-dependency passthrough proxy (plus a Claude Code
+plugin) that sits between Claude Code and DeepSeek's Anthropic-compatible
+endpoint and rewrites the cache-relevant bytes of every request — deterministic
+tool ordering, volatile env-block freezing, per-request nonce stabilization,
+canonical serialization — so the `tools + system` prefix stays byte-identical
+turn after turn and is served from DeepSeek's cache at ~2% of the miss price.
+
+Measured on real Claude Code traffic against the live API: **66% cache hit rate,
+64% lower cost** on a multi-turn agentic task. It also coalesces parallel
+subagent fan-out (one leader warms the cache, followers wait and read it:
+0% → 73% hit measured live) and can keep the prefix warm through idle gaps with
+an opt-in keepalive (99.9% hit on replay).
+
+## UI
+
+```
+$ permafrost status
+mode=aggressive  upstream=https://api.deepseek.com/anthropic  requests=4
+cache hit rate : 66.2%  (41,728 hit / 21,339 miss tokens)
+cost so far    : $0.0032  ($0.0057 saved, 64% vs all-miss)
+prefix resets  : 0
+```
+
+## Integrate with DeepSeek API
+
+Get a DeepSeek API key from <https://platform.deepseek.com/api_keys>, then:
+
+```bash
+git clone https://github.com/jianzhichun/permafrost && cd permafrost
+export ANTHROPIC_API_KEY=YOUR_DEEPSEEK_API_KEY
+./cli/permafrost wrap          # starts the proxy and launches Claude Code through it
+```
+
+`wrap` points Claude Code at the local proxy (`ANTHROPIC_BASE_URL=http://127.0.0.1:8787`,
+`ENABLE_TOOL_SEARCH=true`) and the proxy forwards to
+`https://api.deepseek.com/anthropic`. Watch live savings with
+`./cli/permafrost status`, or diagnose cache busts with `./cli/permafrost doctor`.
+
+Claude Code users can also install it as a plugin:
+
+```
+/plugin marketplace add jianzhichun/permafrost
+/plugin install permafrost@permafrost
+```

--- a/docs/permafrost/README_cn.md
+++ b/docs/permafrost/README_cn.md
@@ -1,0 +1,44 @@
+<div style="font-size: 64px">❄️</div>
+
+# [Permafrost](https://github.com/jianzhichun/permafrost)
+
+冻结 Claude Code 的提示词前缀,让 DeepSeek 的自动上下文缓存每轮都命中。
+Permafrost 是一个零依赖的透传代理(同时也是 Claude Code 插件),位于 Claude Code
+与 DeepSeek 的 Anthropic 兼容端点之间,重写每条请求中与缓存相关的字节——工具确定性
+排序、易变环境块冻结、每请求随机数固定、规范化序列化——使 `tools + system` 前缀逐轮
+字节级一致,以未命中价约 2% 的成本从 DeepSeek 缓存读取。
+
+在真实 Claude Code 流量上对线上 API 实测:多轮 agent 任务 **缓存命中率 66%、成本降低
+64%**。还支持并行子代理扇出合并(leader 暖缓存、follower 等待后读取,实测 0% → 73%
+命中)以及可选的空闲保温(回放命中 99.9%)。
+
+## 界面
+
+```
+$ permafrost status
+mode=aggressive  upstream=https://api.deepseek.com/anthropic  requests=4
+cache hit rate : 66.2%  (41,728 hit / 21,339 miss tokens)
+cost so far    : $0.0032  ($0.0057 saved, 64% vs all-miss)
+prefix resets  : 0
+```
+
+## 接入 DeepSeek API
+
+在 <https://platform.deepseek.com/api_keys> 获取 API key,然后:
+
+```bash
+git clone https://github.com/jianzhichun/permafrost && cd permafrost
+export ANTHROPIC_API_KEY=YOUR_DEEPSEEK_API_KEY
+./cli/permafrost wrap          # 启动代理并让 Claude Code 经由它访问 DeepSeek
+```
+
+`wrap` 会把 Claude Code 指向本地代理(`ANTHROPIC_BASE_URL=http://127.0.0.1:8787`、
+`ENABLE_TOOL_SEARCH=true`),代理转发到 `https://api.deepseek.com/anthropic`。
+用 `./cli/permafrost status` 查看实时省钱数据,用 `./cli/permafrost doctor` 诊断缓存失效原因。
+
+Claude Code 用户也可以作为插件安装:
+
+```
+/plugin marketplace add jianzhichun/permafrost
+/plugin install permafrost@permafrost
+```


### PR DESCRIPTION
## What

Adds **[Permafrost](https://github.com/jianzhichun/permafrost)** to the **Others** section (README.md + README_cn.md), with bilingual integration docs under `docs/permafrost/`.

## Why it belongs here

Permafrost is built specifically around the DeepSeek API: it is a zero-dependency passthrough proxy (and Claude Code plugin) for DeepSeek's **Anthropic-compatible endpoint** (`https://api.deepseek.com/anthropic`) that keeps the prompt prefix byte-stable so DeepSeek's **automatic context caching** keeps hitting — deterministic tool ordering, env-block freezing, nonce stabilization, canonical serialization, cold-anchor coalescing for parallel subagents, and an opt-in idle keepalive.

Measured against the live DeepSeek API on real Claude Code traffic (reproducible via `e2e/run_claude_code.sh` in the repo): **66% cache hit rate / 64% lower cost** on a multi-turn agentic task; coalescing takes concurrent cold fan-out from 0% → 73% hit. The repo also documents measured DeepSeek cache behavior (prefix-unit matching, header-fingerprint cache identity) in `docs/e2e-findings.md`.

MIT licensed, no telemetry, runs entirely locally.