### PR TITLE
Add DeepSeekWidget to Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ English / [简体中文](https://github.com/deepseek-ai/awesome-deepseek-integra
         <td>ETOS LLM Studio (ELS) is a flagship AI client explicitly tailored for watchOS and iOS. It features a watch-first design, aesthetic UI, seamless sync between devices, and deep system integration. Supports multiple models including DeepSeek, redefining AI interaction on your wrist.</td>
     </tr>
     <tr>
+        <td><img src="https://raw.githubusercontent.com/rajit2004/DeepSeekWidget/main/screenshots/deepseek.jpg" alt="Icon" width="64" height="auto" /></td>
+        <td><a href="https://github.com/rajit2004/DeepSeekWidget">DeepSeekWidget</a></td>
+        <td>A lightweight, open-source Android home screen widget providing one-tap access to DeepSeek's chat, voice, and camera features. No unlocking, no menus, zero tracking. APK size ~1 MB.</td>
+    </tr>
+    <tr>
         <td><img src="docs/operit/assets/logo.png" alt="Icon" width="64" height="auto" /></td>
         <td><a href="https://github.com/AAswordman/Operit">Operit AI</a></td>
         <td>An open-source system integration AI assistant for the Android platform, supporting almost complete mcp usage and highly compatible with the Android system. The software features both high customization and a low learning threshold, with built-in tools for file operations, searches, automatic clicks, format conversions, and an integrated DeepSeek API webpage.</td>


### PR DESCRIPTION
## 📱 Add DeepSeekWidget – A 1‑Tap Android Home Screen Widget for DeepSeek

This PR adds [**DeepSeekWidget**](https://github.com/rajit2004/DeepSeekWidget) to the **Applications** section.

### What it does
DeepSeekWidget is a lightweight, open‑source Android home screen widget that gives users **instant, one‑tap access** to DeepSeek’s core features:
- 💬 **Chat** – opens DeepSeek directly (app or web fallback)
- 🎙️ **Voice** – tap, speak, and the transcribed text is sent to DeepSeek’s composer
- 📷 **Camera** – snap a photo and share it immediately for visual analysis

All from the home screen – no unlocking, no menu navigation, no extra taps.

### Why it stands out
- **Extremely lightweight** – APK size is only **~1 MB**
- **Privacy first** – zero analytics, zero tracking, no background services (no battery drain)
- **Pure router** – collects no data; only passes intents to the official DeepSeek app or web fallback
- **Material You** – adapts automatically to system light/dark theme

### Technical highlight (for developers)
Android widgets cannot directly access microphone or camera. DeepSeekWidget solves this with a **"trampoline activity"** – a transparent, invisible activity that handles speech recognition, camera capture, and secure file sharing (via FileProvider) before routing to DeepSeek. This pattern is the only reliable way to build feature‑rich widgets without hitting `RemoteViews` limitations.

### Checkbox compliance
- ✅ Open source (MIT)
- ✅ Directly enhances DeepSeek user experience
- ✅ Clear, well‑documented README with setup and usage instructions
- ✅ Active, maintainable codebase (Kotlin 2.0, minSdk 26)

### Links
- GitHub: https://github.com/rajit2004/DeepSeekWidget
- Direct APK download available in Releases

Thank you for considering this addition to the awesome list!