### PR TITLE
Add Neutrino API to Providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1148,6 +1148,11 @@ The purpose is to build infrastructure in the field of large models, through the
         <td> <a href="https://docs.aimlapi.com/api-references/text-models-llm?utm_source=awesome-deepseek-integrations&utm_medium=github&utm_campaign=integration"> AI/ML API </a> </td>
         <td> AI/ML API gives users enterprise-grade access to 200+ models with just one API. This includes Deepseek R1 and V3, alongside closed and open-source models. All at 99% uptime and with 24/7 human support.</td>
     </tr>
+      <tr>
+        <td> - </td>
+        <td> <a href="https://neutrinoitapi.com"> Neutrino API </a> </td>
+        <td> OpenAI-compatible DeepSeek API access with USD credit card payment. No +86 Chinese phone number or Alipay required. $5 flat for 5 million tokens. Streaming and non-streaming supported.</td>
+    </tr>
 </table>
 
 <p style="text-align: right;"><a href="#table-of-contents">^ Back to Contents ^</a></p>

--- a/README.md
+++ b/README.md
@@ -1148,6 +1148,11 @@ The purpose is to build infrastructure in the field of large models, through the
         <td> <a href="https://docs.aimlapi.com/api-references/text-models-llm?utm_source=awesome-deepseek-integrations&utm_medium=github&utm_campaign=integration"> AI/ML API </a> </td>
         <td> AI/ML API gives users enterprise-grade access to 200+ models with just one API. This includes Deepseek R1 and V3, alongside closed and open-source models. All at 99% uptime and with 24/7 human support.</td>
     </tr>
+    <tr>
+        <td> - </td>
+        <td> <a href="https://neutrinoitapi.com"> Neutrino API </a> </td>
+        <td> OpenAI-compatible DeepSeek API access with USD credit card payment. No +86 Chinese phone number or Alipay required. $5 flat for 5 million tokens. Streaming and non-streaming supported.</td>
+    </tr>
 </table>
 
 <p style="text-align: right;"><a href="#table-of-contents">^ Back to Contents ^</a></p>

--- a/README.md
+++ b/README.md
@@ -1148,11 +1148,6 @@ The purpose is to build infrastructure in the field of large models, through the
         <td> <a href="https://docs.aimlapi.com/api-references/text-models-llm?utm_source=awesome-deepseek-integrations&utm_medium=github&utm_campaign=integration"> AI/ML API </a> </td>
         <td> AI/ML API gives users enterprise-grade access to 200+ models with just one API. This includes Deepseek R1 and V3, alongside closed and open-source models. All at 99% uptime and with 24/7 human support.</td>
     </tr>
-      <tr>
-        <td> - </td>
-        <td> <a href="https://neutrinoitapi.com"> Neutrino API </a> </td>
-        <td> OpenAI-compatible DeepSeek API access with USD credit card payment. No +86 Chinese phone number or Alipay required. $5 flat for 5 million tokens. Streaming and non-streaming supported.</td>
-    </tr>
 </table>
 
 <p style="text-align: right;"><a href="#table-of-contents">^ Back to Contents ^</a></p>


### PR DESCRIPTION
Neutrino API is an OpenAI-compatible gateway for DeepSeek models. It enables developers to access DeepSeek API by paying in USD with a credit card — no Chinese phone number or Alipay/WeChat required.

- $5 flat for 5 million tokens
- OpenAI-compatible /v1/chat/completions endpoint
- Both streaming (SSE) and non-streaming supported

Website: https://neutrinoitapi.com