### PR TITLE
Add qq-ai-bot to IM Application Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -782,6 +782,11 @@ The purpose is to build infrastructure in the field of large models, through the
         <td> Nekro Agent is a smart and elegant AI agent execution framework. At its core, it leverages a powerful and flexible prompt engineering system to guide AI in generating code and executing it within a secure sandbox. It delivers robust cross-platform event stream processing through a native multi-platform adapter architecture, seamlessly supporting major platforms like OneBot v11 (QQ), Discord, Minecraft, and Bilibili Live (powering V-Tuber performances). The project also boasts a highly extensible plugin system, a shared ecosystem for personas and plugins, and supports efficient interactions in complex, multi-user group chats. Its goal is to offer both users and developers a developer-friendly intelligent hub that is extremely efficient, highly flexible, and easy to use. </td>
     </tr>
     <tr>
+        <td> <img src="https://avatars.githubusercontent.com/u/73147033?v=4" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://github.com/happysnaker/qq-ai-bot">qq-ai-bot<br/>（QQ, OneBot 11, NapCat, LLOneBot）</a> </td>
+        <td> Self-hosted QQ ↔ AI bot scaffold for OneBot 11 / NapCat / LLOneBot with ACP-compatible agents. Works well as a QQ-facing integration layer for DeepSeek-backed local agents, with persistent sessions, progress streaming, `/metrics`, and a Docker demo stack.</td>
+    </tr>
+    <tr>
         <td> <img src="https://www.lanyingim.com/img/header/dock_lanying.png" alt="Icon" width="64" height="auto" /> </td>
         <td> <a href="https://www.lanyingim.com">蓝莺IM<br/></a> </td>
         <td> <b>AI Chatbot SDK with IM cloud service</b>, <br/> Cross-platform (iOS, Android, Web, PC, Linux) <a href="https://github.com/maxim-top/maxim-bistro">chat SDK</a> and AI Agent platform. <br/> Easily integrates into apps, and supports WeChat and official accounts. <br/> Native DeepSeek support, no API-Key needed.</td>

--- a/README_cn.md
+++ b/README_cn.md
@@ -644,6 +644,11 @@
         <td> Nekro Agent 是一个智能优雅的 AI 代理执行框架，其核心是通过强大灵活的提示词构建系统，引导 AI 生成代码并在安全的沙盒环境中执行。它通过原生的多平台适配器架构实现了强大的跨平台事件流处理能力，能够无缝支持 OneBot v11 (QQ)、Discord、Minecraft 和 B站直播(驱动VTB进行演出) 等多种主流平台。项目还拥有高度可扩展的插件系统、人设与插件共享生态，并支持在复杂的群聊多人交互场景中进行高效互动。目标是为用户和开发者提供极致高效、高自由度与易用性的开发友好型智能中枢。</td>
     </tr>
     <tr>
+        <td> <img src="https://avatars.githubusercontent.com/u/73147033?v=4" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://github.com/happysnaker/qq-ai-bot">qq-ai-bot<br/>（QQ, OneBot 11, NapCat, LLOneBot）</a> </td>
+        <td> 面向 OneBot 11 / NapCat / LLOneBot 的自托管 QQ ↔ AI 机器人脚手架，支持 ACP 兼容 agent。很适合作为 DeepSeek 等本地 / 自托管 agent 的 QQ 接入层，内置会话持久化、进度回传、`/metrics` 和 Docker 演示栈。</td>
+    </tr>
+    <tr>
         <td> <img src="https://www.lanyingim.com/img/header/dock_lanying.png" alt="Icon" width="64" height="auto" /> </td>
         <td> <a href="https://www.lanyingim.com">蓝莺IM<br/></a> </td>
         <td> <b>AI Chatbot SDK 和云服务</b>，<br>包括一个跨平台（iOS、安卓、网页、PC、Linux等）的<a href="https://github.com/maxim-top/maxim-bistro">聊天SDK</a>和一个AI Agent平台。<br/> 可嵌入应用APP，支持对接微信、公众号。<br/> 原生支持DeepSeek，无需单独配置API-Key。</td>

--- a/README_es.md
+++ b/README_es.md
@@ -621,6 +621,11 @@ Integra la API de DeepSeek en softwares populares. Accede a la [Plataforma Abier
         <td> <a href="https://github.com/KomoriDev/nonebot-plugin-deepseek">NoneBot<br/>（QQ, Lark, Discord, TG, etc.）</a> </td>
         <td> Basado en el marco NoneBot, proporciona funciones de chat inteligente y pensamiento profundo, compatible con QQ, Lark, Discord, TG y más plataformas.</td>
     </tr>
+    <tr>
+        <td> <img src="https://avatars.githubusercontent.com/u/73147033?v=4" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://github.com/happysnaker/qq-ai-bot">qq-ai-bot<br/>（QQ, OneBot 11, NapCat, LLOneBot）</a> </td>
+        <td> Un scaffold autoalojado de bot QQ ↔ AI para OneBot 11 / NapCat / LLOneBot con agentes compatibles con ACP. Encaja bien como capa de integración orientada a QQ para agentes locales basados en DeepSeek, con sesiones persistentes, streaming de progreso, `/metrics` y una pila demo con Docker.</td>
+    </tr>
 </table>
 
 <p style="text-align: right;"><a href="#tabla-de-contenidos">^ Volver al índice ^</a></p>

--- a/README_ja.md
+++ b/README_ja.md
@@ -557,6 +557,11 @@ DeepSeek API を人気のソフトウェアに統合します。API キーを取
         <td> NoneBotフレームワークを基に、インテリジェントな会話と深い思考機能をサポートします。QQ/飛書/Discord/Telegram等多种多様なメッセージプラットフォームに対応しています </td>
     </tr>
     <tr>
+        <td> <img src="https://avatars.githubusercontent.com/u/73147033?v=4" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://github.com/happysnaker/qq-ai-bot">qq-ai-bot<br/>（QQ, OneBot 11, NapCat, LLOneBot）</a> </td>
+        <td> OneBot 11 / NapCat / LLOneBot 向けのセルフホスト型 QQ ↔ AI ボットスキャフォールドで、ACP 互換エージェントをサポートします。DeepSeek などのローカル / セルフホスト型エージェントを QQ に接続する統合レイヤーとして使いやすく、セッション永続化、進捗ストリーミング、`/metrics`、Docker デモスタックを備えています。</td>
+    </tr>
+    <tr>
         <td> <img src="https://github.com/Soulter/AstrBot/raw/refs/heads/master/dashboard/src/assets/images/logo-normal.svg" alt="Icon" width="64" height="auto" /> </td>
         <td> <a href="https://github.com/Soulter/AstrBot/">AstrBot<br/>（QQ, WeChat, WeCom, Lark, TG, etc.）</a> </td>
         <td> 大規模言語モデルをサポートするマルチプラットフォームチャットボットおよび開発フレームワーク。RAG、長期記憶、ウェブ検索などの各種LLMエージェント機能をサポートし、プラグイン開発にも対応。</td>

--- a/README_zh_tw.md
+++ b/README_zh_tw.md
@@ -661,6 +661,11 @@
         <td> 基於 NoneBot 框架，提供智慧聊天和深度思考功能，支援 QQ、飛書、Discord、TG 等多個平台。</td>
     </tr>
     <tr>
+        <td> <img src="https://avatars.githubusercontent.com/u/73147033?v=4" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://github.com/happysnaker/qq-ai-bot">qq-ai-bot<br/>（QQ, OneBot 11, NapCat, LLOneBot）</a> </td>
+        <td> 面向 OneBot 11 / NapCat / LLOneBot 的自託管 QQ ↔ AI 機器人腳手架，支援 ACP 相容 agent。很適合作為 DeepSeek 等本地 / 自託管 agent 的 QQ 接入層，內建會話持久化、進度回傳、`/metrics` 與 Docker 示範棧。</td>
+    </tr>
+    <tr>
         <td> <img src="https://github.com/Soulter/AstrBot/raw/refs/heads/master/dashboard/src/assets/images/logo-normal.svg" alt="Icon" width="64" height="auto" /> </td>
         <td> <a href="https://github.com/Soulter/AstrBot/">AstrBot<br/>（QQ, 微信, 企業微信, 飛書, TG 等）</a> </td>
         <td> 易上手的大模型多平台聊天機器人及開發框架。支援長期記憶、RAG、LLM 代理(agents)和外掛程式整合。</td>


### PR DESCRIPTION
This adds `qq-ai-bot` under **IM Application Plugins**.

Why it fits:
- it is a self-hosted **QQ ↔ AI** bot scaffold for **OneBot 11 / NapCat / LLOneBot**
- it supports **ACP-compatible agents**, so it works well as a **QQ-facing integration layer for DeepSeek-backed local agents**
- the public repo already documents persistent sessions, progress streaming, `/metrics`, and a Docker demo stack

I updated the English, Simplified Chinese, Traditional Chinese, Japanese, and Spanish README files to match the repo's multilingual structure for this section.
