### PR TITLE
Add Lynkr (self-hosted LLM gateway with DeepSeek reasoning-tier support)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1206,6 +1206,11 @@ The purpose is to build infrastructure in the field of large models, through the
         <td> Python SDK, Proxy Server (LLM Gateway) to call 100+ LLM APIs in OpenAI format. Supports DeepSeek AI with cost tracking as well. </td>
     </tr>
     <tr>
+        <td> <img src="https://raw.githubusercontent.com/Fast-Editor/Lynkr/main/docs/og-image.png" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://github.com/Fast-Editor/Lynkr"> Lynkr </a> </td>
+        <td> Self-hosted LLM gateway that routes AI coding tools (Claude Code, Cursor, Codex CLI) by request complexity. Supports DeepSeek as the reasoning/complex tier, with tool-output compression, prompt caching, and semantic caching. Apache-2.0, Node.js. </td>
+    </tr>
+    <tr>
         <td> <img src="https://i.postimg.cc/k5Z4YWjt/Screenshot-2025-01-23-at-6-08-01-PM.png" alt="Icon" width="64" height="auto" /> </td>
         <td> <a href="https://github.com/mem0ai/mem0"> Mem0 </a> </td>
         <td> Mem0 enhances AI assistants with an intelligent memory layer, enabling personalized interactions and continuous learning over time. </td>


### PR DESCRIPTION
Adds Lynkr to the Others section, next to the existing gateway entries (LiteLLM, Portkey).

Lynkr is an Apache-2.0, self-hosted LLM gateway for AI coding tools (Claude Code, Cursor, Codex CLI, Cline, Continue). It scores each request's complexity and routes it across configured providers — DeepSeek is supported as the REASONING/COMPLEX tier (our docs use DeepSeek R1 as the example reasoning model). It also strips unused tool schemas, compresses large JSON tool results, and adds semantic caching.

Repo: https://github.com/Fast-Editor/Lynkr

Entry follows the existing table format with a remote icon URL, matching the LiteLLM/Portkey rows.