### PR TITLE
Add Orca — DeepSeek-native terminal coding agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1310,6 +1310,11 @@ The purpose is to build infrastructure in the field of large models, through the
         <td> <a href="https://github.com/informatico-madrid/blackwell-linux-infra-optimizer"> Blackwell Linux Infra Optimizer </a> </td>
         <td> Optimized vLLM stack for NVIDIA Blackwell (SM_120) and Linux Kernel 6.14. Achieving 59.0 t/s on DeepSeek-R1-32B using native FlashInfer backend. </td>
     </tr>
+    <tr>
+        <td> <img src="https://orcaagent.dev/orca-icon.svg" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://github.com/echoVic/blade-deepseek">Orca</a> </td>
+        <td> <a href="https://github.com/echoVic/blade-deepseek">Orca</a> is a DeepSeek-native terminal coding agent written in Rust. It runs a multi-turn agent loop with persistent goals, multi-stage workflow orchestration, subagents, capability-based approval policies, prefix-cache-friendly prompt construction, and automatic 1M-token context management. </td>
+    </tr>
 </table>
 
 <p style="text-align: right;"><a href="#table-of-contents">^ Back to Contents ^</a></p>

--- a/README_cn.md
+++ b/README_cn.md
@@ -1005,6 +1005,11 @@
         <td> <a href="https://github.com/sally-suite/open-office-copilot">Open Office Copilot</a> </td>
         <td> Open Office Copilot 是一个开源的 Office 助手，支持 Microsoft Office 和 Google Workspace，基于 AI-Agent。它可以帮助你在 Word 中写作、在 PowerPoint 中生成幻灯片、在 Excel 中分析数据、在 Outlook 里帮你生成邮件等，现在已经集成了 DeepSeek。</td>
     </tr>
+    <tr>
+        <td> <img src="https://orcaagent.dev/orca-icon.svg" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://github.com/echoVic/blade-deepseek">Orca</a> </td>
+        <td> <a href="https://github.com/echoVic/blade-deepseek">Orca</a> 是一个 DeepSeek 原生的终端 Coding Agent（Rust 编写）。支持持久 Goal 模式、多阶段 Workflow 编排、子 Agent、按工具能力分级的审批策略、前缀缓存友好的请求构造，以及 1M token 上下文自动管理。 </td>
+    </tr>
 </table>
 
 <p style="text-align: right;"><a href="#目录">^ 返回目录 ^</a></p>


### PR DESCRIPTION
## What

Adds **Orca** to the **Others** section (README.md + README_cn.md), next to the existing terminal/CLI tools.

- Repo: https://github.com/echoVic/blade-deepseek
- Website: https://orcaagent.dev

## Why it belongs here

Orca is a terminal coding agent built specifically for the DeepSeek API (not a generic multi-provider wrapper):

- Multi-turn agent loop with reasoning/content dual-stream SSE parsing, empty-turn recovery, and max reasoning effort by default
- Prefix-cache-friendly request construction: append-only conversation history and byte-stable tool schema serialization, so long agent sessions keep hitting DeepSeek's context cache; `prompt_cache_hit_tokens` is parsed and shown in the live cost display
- Automatic 1M-token context management with compaction at an 80% threshold
- Persistent goal mode, multi-stage workflow orchestration, subagents, and capability-based tool approval
- Single binary (Rust), installable via npm (`@blade-ai/orca`) or curl; macOS and Linux

Both English and Chinese README tables are updated with the same entry.