### PR TITLE
Add Orkas to Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,6 +557,11 @@ With these functionalities, the AI assistant can summarize key points within an 
         <td> <a href="https://github.com/songquanpeng/one-api">One API</a> </td>
         <td> One API is a LLM API management & key redistribution system, unifying multiple providers under a single API. Single binary, Docker-ready, with an English UI.</td>
     </tr>
+    <tr>
+        <td width=80> <img src="https://raw.githubusercontent.com/Orkas-AI/Orkas/main/src/resources/icons/logo.png" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://orkas.ai/?source=awesome_deepseek">Orkas</a> </td>
+        <td>Orkas is an MIT-licensed, local-first multi-agent desktop application where a Commander coordinates specialist agents for research, coding, data analysis, documents, and media. It supports direct DeepSeek API configuration with users' own keys.</td>
+    </tr>
 </table>
 
 <p style="text-align: right;"><a href="#table-of-contents">^ Back to Contents ^</a></p>

--- a/README_cn.md
+++ b/README_cn.md
@@ -471,6 +471,11 @@
         <td> <a href="https://www.aispire.info">AIspire</a> </td>
         <td> AIspire是一个辅助AI学术写作的全能助手，从学术问题解答、学术灵感发现、文献管理、辅助阅读到全自动化AI辅助写作，让你的科研更精准、更高效。 </td>
     </tr>
+    <tr>
+        <td width=80> <img src="https://raw.githubusercontent.com/Orkas-AI/Orkas/main/src/resources/icons/logo.png" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://orkas.ai/?source=awesome_deepseek">Orkas</a> </td>
+        <td>Orkas 是一款采用 MIT 许可证、本地优先的多智能体桌面应用。Commander 可协调调研、编程、数据分析、文档和媒体等专业智能体，并支持用户使用自己的 API Key 直接配置 DeepSeek。</td>
+    </tr>
 </table>
 
 <p style="text-align: right;"><a href="#目录">^ 返回目录 ^</a></p>

--- a/README_es.md
+++ b/README_es.md
@@ -432,6 +432,11 @@ Integra la API de DeepSeek en softwares populares. Accede a la [Plataforma Abier
         <td> <a href="https://turtlenoir.com/"> Turtle Noir </a> </td>
         <td> <a href="https://turtlenoir.com/"> Turtle Noir </a> Un juego de enigmas de pensamiento lateral tipo "Sopa de Tortuga" con un anfitrión de IA basado en DeepSeek, disponible para uno o varios jugadores. La IA modera la partida e interactúa con humor, guiando la deducción mediante respuestas de "Sí / No / Irrelevante". Ofrece una experiencia inmersiva con una fuerte atmósfera narrativa, gestión del ritmo y un sistema de pistas para evitar bloqueos. Integra búsqueda vectorial y DeepSeek para evitar la repetición de acertijos e incluye moderación de contenido. Ideal para entrenar la creatividad y como entretenimiento social en línea. </td>
     </tr>
+    <tr>
+        <td width=80> <img src="https://raw.githubusercontent.com/Orkas-AI/Orkas/main/src/resources/icons/logo.png" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://orkas.ai/?source=awesome_deepseek">Orkas</a> </td>
+        <td>Orkas es una aplicación de escritorio multiagente, local y con licencia MIT, en la que un Commander coordina agentes especializados en investigación, programación, análisis de datos, documentos y contenido multimedia. Permite configurar directamente la API de DeepSeek con la clave del usuario.</td>
+    </tr>
 </table>
 
 <p style="text-align: right;"><a href="#tabla-de-contenidos">^ Volver al índice ^</a></p>

--- a/README_ja.md
+++ b/README_ja.md
@@ -404,6 +404,11 @@ DeepSeek API を人気のソフトウェアに統合します。API キーを取
         <td> <a href="https://github.com/guyoung/AIMatrices/blob/main/README.md">AIMatrices</a> </td>
         <td>AIMatricesは、効率的で便利なaiアプリケーション開発体験を開発者に提供するために設計された、軽量、高性能、スケーラブルでオープンソースのaiアプリケーション迅速構築プラットフォームです。複数の高度なテクノロジとツールを統合することで、複雑なコードをゼロから作成することなく、ユーザーがaiアプリケーションを迅速に構築、展開、維持できるようになります。</td>
     </tr>
+    <tr>
+        <td width=80> <img src="https://raw.githubusercontent.com/Orkas-AI/Orkas/main/src/resources/icons/logo.png" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://orkas.ai/?source=awesome_deepseek">Orkas</a> </td>
+        <td>Orkas は MIT ライセンスのローカルファーストなマルチエージェント・デスクトップアプリです。Commander が調査、コーディング、データ分析、文書、メディアを担当する専門エージェントを連携させ、ユーザー自身の API キーで DeepSeek を直接設定できます。</td>
+    </tr>
 </table>
 
 <p style="text-align: right;"><a href="#目次">^ 目次に戻る ^</a></p>

--- a/README_zh_tw.md
+++ b/README_zh_tw.md
@@ -470,6 +470,11 @@
         <td> <a href="https://haiguitang.net/"> Turtle Noir </a> </td>
         <td> <a href="https://haiguitang.net/"> Turtle Noir </a> 基於 DeepSeek 的 AI 主持人海龜湯 / 側向思維解謎產品，可單人或者多人遊玩。AI 進行控場與吐槽，圍繞「是 / 否 / 無關」的問答推進推理；提供沉浸式玩法（更強劇情氛圍與節奏引導）、引導提示與防卡關機制，同時結合向量檢索 + DeepSeek 進行題目去重，並提供內容審核能力。適合輕量腦洞訓練與在線陪玩。 </td>
     </tr>
+    <tr>
+        <td width=80> <img src="https://raw.githubusercontent.com/Orkas-AI/Orkas/main/src/resources/icons/logo.png" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://orkas.ai/?source=awesome_deepseek">Orkas</a> </td>
+        <td>Orkas 是一款採用 MIT 授權、本機優先的多智慧體桌面應用程式。Commander 可協調研究、程式設計、資料分析、文件與媒體等專業智慧體，並支援使用者以自己的 API Key 直接設定 DeepSeek。</td>
+    </tr>
 </table>
 
 <p style="text-align: right;"><a href="#目錄">^ 返回目錄 ^</a></p>


### PR DESCRIPTION
Adds [Orkas](https://github.com/Orkas-AI/Orkas) to the Applications section in all five localized README files.

- Orkas supports direct DeepSeek API configuration with user-provided keys.
- It is an MIT-licensed, local-first multi-agent desktop application.
- The same application entry is provided in English, Simplified Chinese, Spanish, Japanese, and Traditional Chinese.
- The icon is loaded from the Orkas open-source repository.
