### PR TITLE
Add Agent4API integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -620,6 +620,11 @@ With these functionalities, the AI assistant can summarize key points within an 
         <td> <a href="https://github.com/guyoung/AIMatrices/blob/main/README.md">AIMatrices</a> </td>
         <td>AIMatrices is a lightweight, high-performance, scalable, and open source AI application rapid building platform designed to provide developers with an efficient and convenient AI application development experience. It integrates multiple advanced technologies and tools to help users quickly build, deploy, and maintain AI applications without having to write complex code from scratch.</td>
     </tr>
+    <tr>
+        <td> <img src="https://raw.githubusercontent.com/apoet/Agent4API/main/logo.png" alt="Agent4API icon" width="64" height="auto" /> </td>
+        <td> <a href="https://github.com/apoet/Agent4API">Agent4API</a> </td>
+        <td>Agent4API turns Swagger/OpenAPI definitions into managed Tools, Skills, and AI Agents in one click. It supports DeepSeek through OpenAI-compatible providers and exposes agents through MCP, OpenAI-compatible and Anthropic-compatible APIs, browser chat, and embeddable chat.</td>
+    </tr>
 </table>
 
 ### RAG frameworks

--- a/README_cn.md
+++ b/README_cn.md
@@ -529,6 +529,11 @@
         <td> <a href="https://github.com/Tencent/Youtu-agent/"> Youtu-Agent </a> </td>
         <td> <a href="https://github.com/Tencent/Youtu-agent/"> Youtu-Agent </a> 是一个灵活、高性能的框架，用于构建、运行和评估自主智能体。除了在基准测试中名列前茅，该框架还提供了强大的智能体能力，采用开源模型即可实现例如数据分析、文件处理、深度研究等功能。 </td>
     </tr>
+    <tr>
+        <td> <img src="https://raw.githubusercontent.com/apoet/Agent4API/main/logo.png" alt="Agent4API 图标" width="64" height="auto" /> </td>
+        <td> <a href="https://github.com/apoet/Agent4API">Agent4API</a> </td>
+        <td>Agent4API 可一键将 Swagger/OpenAPI 定义转换为受管控的工具、技能和 AI 智能体。它通过 OpenAI 兼容的提供商支持 DeepSeek，并可通过 MCP、OpenAI/Anthropic 兼容 API、浏览器聊天及嵌入式聊天对外提供智能体服务。</td>
+    </tr>
 </table>
 
 <p style="text-align: right;"><a href="#目录">^ 返回目录 ^</a></p>


### PR DESCRIPTION
## What changed

- Add Agent4API to the AI Agent frameworks section in README.md.
- Add the corresponding Simplified Chinese entry to README_cn.md.
- Use the project official logo and repository link.

## Why

Agent4API turns Swagger/OpenAPI definitions into managed Tools, Skills, and AI Agents. It supports DeepSeek through OpenAI-compatible providers and exposes agents through MCP, OpenAI-compatible and Anthropic-compatible APIs, browser chat, and embeddable chat.

## Validation

- git diff --check
- Verified the Agent4API repository and logo URLs return HTTP 200.
- Confirmed the branch is based on the current upstream main.