### PR TITLE
Add Jig to AI Agent frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,7 +622,7 @@ With these functionalities, the AI assistant can summarize key points within an 
     </tr>
 
     <tr>
-        <td> <img src="https://avatars.githubusercontent.com/u/72914563?v=4" alt="Icon" width="64" height="auto" /> </td>
+        <td> <img src="https://raw.githubusercontent.com/deepseek-ai/awesome-deepseek-integration/main/docs/jig/assets/jig-mark-color.svg" alt="Icon" width="64" height="auto" /> </td>
         <td> <a href="https://github.com/deepseek-ai/awesome-deepseek-integration/blob/main/docs/jig/README.md">Jig</a> </td>
         <td>Python multi-agent orchestration framework with pre-execution Agent Firewall, 4-layer memory, and DeepSeek-native optimizations (SHA-256 prefix caching, CostAwareRouter, Tool-Call Repair).</td>
     </tr>

--- a/README.md
+++ b/README.md
@@ -620,6 +620,13 @@ With these functionalities, the AI assistant can summarize key points within an 
         <td> <a href="https://github.com/guyoung/AIMatrices/blob/main/README.md">AIMatrices</a> </td>
         <td>AIMatrices is a lightweight, high-performance, scalable, and open source AI application rapid building platform designed to provide developers with an efficient and convenient AI application development experience. It integrates multiple advanced technologies and tools to help users quickly build, deploy, and maintain AI applications without having to write complex code from scratch.</td>
     </tr>
+
+    <tr>
+        <td> <img src="https://avatars.githubusercontent.com/u/72914563?v=4" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://github.com/deepseek-ai/awesome-deepseek-integration/blob/main/docs/jig/README.md">Jig</a> </td>
+        <td>Python multi-agent orchestration framework with pre-execution Agent Firewall, 4-layer memory, and DeepSeek-native optimizations (SHA-256 prefix caching, CostAwareRouter, Tool-Call Repair).</td>
+    </tr>
+
 </table>
 
 ### RAG frameworks

--- a/README_cn.md
+++ b/README_cn.md
@@ -531,7 +531,7 @@
     </tr>
 
     <tr>
-        <td> <img src="https://avatars.githubusercontent.com/u/72914563?v=4" alt="图标" width="64" height="auto" /> </td>
+        <td> <img src="https://raw.githubusercontent.com/deepseek-ai/awesome-deepseek-integration/main/docs/jig/assets/jig-mark-color.svg" alt="图标" width="64" height="auto" /> </td>
         <td> <a href="https://github.com/deepseek-ai/awesome-deepseek-integration/blob/main/docs/jig/README_cn.md">Jig</a> </td>
         <td> Python 多 Agent 编排框架，具备执行前 Agent Firewall、4 层记忆架构和 DeepSeek 原生优化（SHA-256 前缀缓存、CostAwareRouter、Tool-Call Repair）。 </td>
     </tr>

--- a/README_cn.md
+++ b/README_cn.md
@@ -529,6 +529,13 @@
         <td> <a href="https://github.com/Tencent/Youtu-agent/"> Youtu-Agent </a> </td>
         <td> <a href="https://github.com/Tencent/Youtu-agent/"> Youtu-Agent </a> 是一个灵活、高性能的框架，用于构建、运行和评估自主智能体。除了在基准测试中名列前茅，该框架还提供了强大的智能体能力，采用开源模型即可实现例如数据分析、文件处理、深度研究等功能。 </td>
     </tr>
+
+    <tr>
+        <td> <img src="https://avatars.githubusercontent.com/u/72914563?v=4" alt="图标" width="64" height="auto" /> </td>
+        <td> <a href="https://github.com/deepseek-ai/awesome-deepseek-integration/blob/main/docs/jig/README_cn.md">Jig</a> </td>
+        <td> Python 多 Agent 编排框架，具备执行前 Agent Firewall、4 层记忆架构和 DeepSeek 原生优化（SHA-256 前缀缓存、CostAwareRouter、Tool-Call Repair）。 </td>
+    </tr>
+
 </table>
 
 <p style="text-align: right;"><a href="#目录">^ 返回目录 ^</a></p>

--- a/docs/jig/README.md
+++ b/docs/jig/README.md
@@ -1,0 +1,55 @@
+# Jig
+
+Jig is a Python multi-agent orchestration framework with **pre-execution safety gates** (Agent Firewall), 4-layer memory architecture, and a hard-constraint Harness layer. It's optimized for DeepSeek V4's API — SHA-256 prefix caching, flash-first cost routing, and automatic tool-call repair.
+
+## Why Jig?
+
+Most agent frameworks "trust the LLM" and rely on prompt-level constraints. Jig inverts this: every tool call passes through a code-level **Agent Firewall** (whitelist + blacklist + PreToolUse hooks) before execution. This makes agent autonomy safe by construction, not by prompting.
+
+## Features
+
+- 🛡️ **Pre-execution Agent Firewall** — tool whitelist/blacklist enforced in code, not prompt
+- 🧠 **DeepSeek-Native Optimizations** — SHA-256 prefix caching, flash-first CostAwareRouter, Tool-Call Repair
+- 🤖 **11 Preset Agents** — PM, Spec, Coding, Acceptance, Security, TDD, DevOps, Secretary, Mentor, etc.
+- 🌐 **Multi-Model + Streaming** — DeepSeek + OpenAI providers, SSE streaming
+- 🔄 **Loop Engineering** — convergence detection, quality validation, retry + escalate
+- 🗄️ **4-Layer Memory** — append-only, working, compressed, consolidated
+- 🧩 **Graph Orchestration** — complex queries route through graph pipelines
+- 🛡️ **Human-in-the-Loop** — `requires_approval` nodes pause for manual approve/reject
+
+## Installation
+
+```bash
+pip install jig-toolguard
+```
+
+## Quick Start
+
+```python
+from jig import Jig
+
+app = Jig(skills_dir="./skills")
+result = app.run("帮我分析这个需求并拆解任务")
+print(result)
+```
+
+## DeepSeek Integration
+
+Set your API key:
+
+```bash
+export DEEPSEEK_API_KEY="sk-your-key-here"
+```
+
+All agents default to `deepseek-v4-flash` for cost efficiency. Short queries stay on Flash; complex tasks auto-upgrade to `deepseek-v4-pro`. Token budgets prevent runaway costs.
+
+| Model | Cost / 1K tokens |
+|-------|-----------------|
+| deepseek-v4-pro | $0.435 in / $0.87 out |
+| deepseek-v4-flash | $0.14 in / $0.28 out |
+| Cache hit | 2% of base price |
+
+## Links
+
+- GitHub: https://github.com/luyi14-bits/jig
+- PyPI: https://pypi.org/project/jig-toolguard/

--- a/docs/jig/README_cn.md
+++ b/docs/jig/README_cn.md
@@ -1,0 +1,55 @@
+# Jig
+
+Jig 是一个 Python 多 Agent 编排框架，具备**执行前安全门禁**（Agent Firewall）、4 层记忆架构和硬约束 Harness 层。针对 DeepSeek V4 API 深度优化 — SHA-256 前缀缓存、Flash 优先成本路由、自动 Tool-Call Repair。
+
+## 为什么选择 Jig？
+
+大多数 Agent 框架"信任 LLM"，依赖 prompt 级约束。Jig 反其道而行：每个工具调用在**代码层**先经过 Agent Firewall（白名单 + 黑名单 + PreToolUse 钩子）再执行。Agent 自主性靠架构保证安全，而非提示词。
+
+## 特性
+
+- 🛡️ **执行前 Agent Firewall** — 工具白名单/黑名单在代码层强制，不靠 prompt
+- 🧠 **DeepSeek 原生优化** — SHA-256 前缀缓存、Flash 优先 CostAwareRouter、Tool-Call Repair
+- 🤖 **11 个预设 Agent** — PM、Spec、Coding、Acceptance、Security、TDD、DevOps、秘书、导师等
+- 🌐 **多模型 + 流式** — DeepSeek + OpenAI provider、SSE 流式输出
+- 🔄 **Loop Engineering** — 收敛检测、质量校验、重试 + 升级
+- 🗄️ **4 层记忆** — append-only、工作区、压缩、整合
+- 🧩 **图编排** — 复杂查询走图管道
+- 🛡️ **Human-in-the-Loop** — `requires_approval` 节点暂停等待人工审批
+
+## 安装
+
+```bash
+pip install jig-toolguard
+```
+
+## 快速开始
+
+```python
+from jig import Jig
+
+app = Jig(skills_dir="./skills")
+result = app.run("帮我分析这个需求并拆解任务")
+print(result)
+```
+
+## DeepSeek 集成
+
+设置 API Key：
+
+```bash
+export DEEPSEEK_API_KEY="sk-your-key-here"
+```
+
+所有 Agent 默认使用 `deepseek-v4-flash` 控制成本。短查询保持 Flash；复杂任务自动升级到 `deepseek-v4-pro`。Token 预算防止成本失控。
+
+| 模型 | 成本 / 1K tokens |
+|-------|-----------------|
+| deepseek-v4-pro | $0.435 in / $0.87 out |
+| deepseek-v4-flash | $0.14 in / $0.28 out |
+| 缓存命中 | 基础价 2% |
+
+## 链接
+
+- GitHub: https://github.com/luyi14-bits/jig
+- PyPI: https://pypi.org/project/jig-toolguard/

--- a/docs/jig/assets/jig-mark-black.svg
+++ b/docs/jig/assets/jig-mark-black.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 240" fill="none">
+  <!-- Jig Logo · Minimal Shield · Black (monochrome) -->
+  <g transform="translate(100,30)">
+    <circle cx="0" cy="0" r="12" stroke="#0F172A" stroke-width="5.5" fill="none"/>
+    <g stroke="#0F172A" stroke-width="5.5" stroke-linecap="round">
+      <line x1="0" y1="-18" x2="0" y2="-22"/>
+      <line x1="0" y1="-18" x2="0" y2="-22" transform="rotate(45)"/>
+      <line x1="0" y1="-18" x2="0" y2="-22" transform="rotate(90)"/>
+      <line x1="0" y1="-18" x2="0" y2="-22" transform="rotate(135)"/>
+      <line x1="0" y1="-18" x2="0" y2="-22" transform="rotate(180)"/>
+      <line x1="0" y1="-18" x2="0" y2="-22" transform="rotate(225)"/>
+      <line x1="0" y1="-18" x2="0" y2="-22" transform="rotate(270)"/>
+      <line x1="0" y1="-18" x2="0" y2="-22" transform="rotate(315)"/>
+    </g>
+  </g>
+  <line x1="36" y1="48" x2="82" y2="48" stroke="#0F172A" stroke-width="5.5" stroke-linecap="round"/>
+  <line x1="118" y1="48" x2="164" y2="48" stroke="#0F172A" stroke-width="5.5" stroke-linecap="round"/>
+  <circle cx="42" cy="40" r="3.5" fill="#0F172A"/>
+  <path d="M40 54 L40 130 Q40 165 58 180 Q76 192 100 192"
+        stroke="#0F172A" stroke-width="5.5" fill="none" stroke-linecap="round"/>
+  <line x1="100" y1="48" x2="100" y2="210" stroke="#0F172A" stroke-width="5.5" stroke-linecap="round"/>
+  <path d="M160 54 L160 72 Q160 84 148 84 L138 84"
+        stroke="#0F172A" stroke-width="5.5" fill="none" stroke-linecap="round"/>
+  <path d="M160 54 L160 130 Q160 165 142 180 Q124 192 100 192"
+        stroke="#0F172A" stroke-width="5.5" fill="none" stroke-linecap="round"/>
+</svg>

--- a/docs/jig/assets/jig-mark-color.svg
+++ b/docs/jig/assets/jig-mark-color.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 240" fill="none">
+  <!-- Jig Logo · Minimal Shield · Color (Navy + Emerald) -->
+  <g transform="translate(100,30)">
+    <circle cx="0" cy="0" r="12" stroke="#10B981" stroke-width="5.5" fill="none"/>
+    <g stroke="#10B981" stroke-width="5.5" stroke-linecap="round">
+      <line x1="0" y1="-18" x2="0" y2="-22"/>
+      <line x1="0" y1="-18" x2="0" y2="-22" transform="rotate(45)"/>
+      <line x1="0" y1="-18" x2="0" y2="-22" transform="rotate(90)"/>
+      <line x1="0" y1="-18" x2="0" y2="-22" transform="rotate(135)"/>
+      <line x1="0" y1="-18" x2="0" y2="-22" transform="rotate(180)"/>
+      <line x1="0" y1="-18" x2="0" y2="-22" transform="rotate(225)"/>
+      <line x1="0" y1="-18" x2="0" y2="-22" transform="rotate(270)"/>
+      <line x1="0" y1="-18" x2="0" y2="-22" transform="rotate(315)"/>
+    </g>
+  </g>
+  <line x1="36" y1="48" x2="82" y2="48" stroke="#1B2A4A" stroke-width="5.5" stroke-linecap="round"/>
+  <line x1="118" y1="48" x2="164" y2="48" stroke="#1B2A4A" stroke-width="5.5" stroke-linecap="round"/>
+  <circle cx="42" cy="40" r="3.5" fill="#1B2A4A"/>
+  <path d="M40 54 L40 130 Q40 165 58 180 Q76 192 100 192"
+        stroke="#1B2A4A" stroke-width="5.5" fill="none" stroke-linecap="round"/>
+  <line x1="100" y1="48" x2="100" y2="210" stroke="#1B2A4A" stroke-width="5.5" stroke-linecap="round"/>
+  <path d="M160 54 L160 72 Q160 84 148 84 L138 84"
+        stroke="#1B2A4A" stroke-width="5.5" fill="none" stroke-linecap="round"/>
+  <path d="M160 54 L160 130 Q160 165 142 180 Q124 192 100 192"
+        stroke="#1B2A4A" stroke-width="5.5" fill="none" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
## Add Jig

Add [Jig](https://github.com/luyi14-bits/jig) — a Python multi-agent orchestration framework with pre-execution safety gates — to the AI Agent frameworks section.

### Highlights

- **Pre-execution Agent Firewall**: tool whitelist/blacklist enforced in code, not prompt
- **DeepSeek-Native Optimizations**: SHA-256 prefix caching, flash-first CostAwareRouter, Tool-Call Repair
- **11 Preset Agents**: PM, Spec, Coding, Acceptance, Security, TDD, DevOps, Secretary, Mentor, etc.
- **Multi-Model + Streaming**: DeepSeek + OpenAI providers, SSE streaming
- **Loop Engineering**: convergence detection, quality validation, retry + escalate
- **4-Layer Memory**: append-only, working, compressed, consolidated

### Files

- `docs/jig/README.md` (EN) + `docs/jig/README_cn.md` (ZH)
- README.md + README_cn.md table rows

Install: `pip install jig-toolguard`