### PR TITLE
Add ArkG AI to ProvidersUpdate README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1141,13 +1141,19 @@ The purpose is to build infrastructure in the field of large models, through the
 <p style="text-align: right;"><a href="#table-of-contents">^ Back to Contents ^</a></p>
 
 ###  <span id="providers">Providers</span>
-
 <table>
     <tr>
         <td> <img src="./docs/aimlapi/aimlapi_logo.png"  alt="Icon" width="64" height="auto" /> </td>
         <td> <a href="https://docs.aimlapi.com/api-references/text-models-llm?utm_source=awesome-deepseek-integrations&utm_medium=github&utm_campaign=integration"> AI/ML API </a> </td>
         <td> AI/ML API gives users enterprise-grade access to 200+ models with just one API. This includes Deepseek R1 and V3, alongside closed and open-source models. All at 99% uptime and with 24/7 human support.</td>
+        </tr>
+
+    <tr>
+        <td>🚀</td>
+        <td><a href="https://arkg.com.cn">ArkG AI</a></td>
+        <td>OpenAI Compatible API platform providing unified access to DeepSeek, Qwen, GLM and other AI models.</td>
     </tr>
+
 </table>
 
 <p style="text-align: right;"><a href="#table-of-contents">^ Back to Contents ^</a></p>


### PR DESCRIPTION
Add ArkG AI to the Providers section.

ArkG AI is an OpenAI Compatible API platform providing unified access to DeepSeek, Qwen, GLM and other AI models.

Website:
https://arkg.com.cn