### PR TITLE
更新Continue补全插件的DeepSeek使用方法

### DIFF
--- a/docs/continue/README_cn.md
+++ b/docs/continue/README_cn.md
@@ -24,7 +24,7 @@ models:
     provider: deepseek
     model: deepseek-chat
     apiKey: YOUR_DEEPSEEK_API_KEY
-    apiBase: https://api.deepseek.com/beta
+    apiBase: https://api.deepseek.com/
     roles:
       - chat
       - edit
@@ -44,3 +44,7 @@ context:
   - provider: folder
   - provider: codebase
 ```
+
+## 修改continue插件的设置
+将超时时间改为3000ms
+<img width="589" height="888" alt="image" src="https://github.com/user-attachments/assets/17fa5925-b8e1-4384-a748-d839c3aff48e" />


### PR DESCRIPTION
Continue插件新版本会加上beta后缀，不需要手动加
DeepSeek的api响应时间可能超过1s，所以原来的150ms超时时间太短了