### PR TITLE
Add BitFun to native AI code editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1088,6 +1088,11 @@ The purpose is to build infrastructure in the field of large models, through the
 
 <table>
     <tr>
+        <td> <img src="https://raw.githubusercontent.com/GCWing/BitFun/main/src/web-ui/public/Logo-ICON-128.png" alt="BitFun icon" width="64" height="auto" /> </td>
+        <td> <a href="https://github.com/GCWing/BitFun"> BitFun </a> </td>
+        <td>An open-source AI agent workbench for real repositories. It supports the official DeepSeek API, including DeepSeek V4 Flash and V4 Pro, alongside other model providers.</td>
+    </tr>
+    <tr>
         <td> <img src="https://avatars.githubusercontent.com/u/126759922?s=200&v=4" alt="Icon" width="64" height="auto" /> </td>
         <td> <a href="https://www.cursor.com/"> Cursor </a> </td>
         <td>‍The AI Code Editor based on VS Code</td>

--- a/README_cn.md
+++ b/README_cn.md
@@ -887,6 +887,11 @@
 
 <table>
     <tr>
+        <td> <img src="https://raw.githubusercontent.com/GCWing/BitFun/main/src/web-ui/public/Logo-ICON-128.png" alt="BitFun 图标" width="64" height="auto" /> </td>
+        <td> <a href="https://github.com/GCWing/BitFun"> BitFun </a> </td>
+        <td> 面向真实代码仓库的开源 AI Agent 工作台，支持包括 DeepSeek V4 Flash 和 V4 Pro 在内的官方 DeepSeek API，也可接入其他模型提供商。 </td>
+    </tr>
+    <tr>
         <td> <img src="https://global.discourse-cdn.com/flex020/uploads/cursor1/original/2X/a/a4f78589d63edd61a2843306f8e11bad9590f0ca.png" alt="Icon" width="64" height="auto" /> </td>
         <td> <a href="https://www.cursor.com/"> Cursor </a> </td>
         <td> 基于VS Code进行扩展的AI Code编辑器 </td>


### PR DESCRIPTION
## Summary

Add BitFun to the Native AI Code Editor section in both English and Simplified Chinese.

BitFun is an open-source AI agent workbench for real repositories. Its current provider catalog includes the official DeepSeek endpoint and DeepSeek V4 Flash / V4 Pro model entries.

## Scope

- Add one entry to `README.md`
- Add the matching entry to `README_cn.md`
- Use the project icon hosted in the BitFun repository