### PR TITLE
Add dsh-cursor-codex to Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,6 +557,11 @@ With these functionalities, the AI assistant can summarize key points within an 
         <td> <a href="https://github.com/songquanpeng/one-api">One API</a> </td>
         <td> One API is a LLM API management & key redistribution system, unifying multiple providers under a single API. Single binary, Docker-ready, with an English UI.</td>
     </tr>
+    <tr>
+        <td><img src="https://raw.githubusercontent.com/jeremy9682/dsh-cursor-codex/main/registry/dsh-acp/icon.svg" alt="Icon" width="64" height="auto" /></td>
+        <td><a href="https://github.com/jeremy9682/dsh-cursor-codex">dsh-cursor-codex</a></td>
+        <td>Connect DeepSeek Harness (dsh) to the Cursor editor and Codex CLI: ACP agent bundle, zero-dependency MCP server, delegation skills, and config templates.</td>
+    </tr>
 </table>
 
 <p style="text-align: right;"><a href="#table-of-contents">^ Back to Contents ^</a></p>


### PR DESCRIPTION
Adds [dsh-cursor-codex](https://github.com/jeremy9682/dsh-cursor-codex) as one Applications row: the integration kit connecting DeepSeek Harness (dsh) to the Cursor editor and Codex CLI (ACP bundle + zero-dependency MCP server + delegation skills + templates, MIT, dsh-plugin topic).

- Verified end-to-end on dsh 0.1.0-rc.6 (ACP: initialize → session/new → session/prompt → end_turn; MCP: tools/list → dsh_health → dsh_delegate).
- Also registered in the ACP registry (agentclientprotocol/registry#509) and the awesome-dsh-plugin list (#270).

Only README.md is updated; the i18n READMEs can be paired in a follow-up if maintainers prefer.