### PR TITLE
docs: add SandBase Harness integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,6 +565,11 @@ With these functionalities, the AI assistant can summarize key points within an 
 
 <table>
     <tr>
+        <td width=80> <img src="https://avatars.githubusercontent.com/u/271874822?s=200&v=4" alt="SandBase" width="64" height="auto" /> </td>
+        <td> <a href="https://github.com/sandbaseai/sandbase-harness">SandBase Harness</a> </td>
+        <td>Local-first managed agent runtime with durable sessions, sandboxed execution, MCP, audit, replay, and verified DeepSeek V4 reasoning controls.</td>
+    </tr>
+    <tr>
         <td width=80> <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/smolagents/mascot_smol.png" alt="Icon" width="64" height="auto" /> </td>
         <td> <a href="https://github.com/huggingface/smolagents/tree/main"> smolagents </a> </td>
         <td> The simplest way to build great agents. Agents write python code to call tools and orchestrate other agents. Priority support for open models like DeepSeek-R1!  </td>

--- a/README_cn.md
+++ b/README_cn.md
@@ -478,6 +478,11 @@
 ###  <span id="agent">AI Agent 框架</span>
 
 <table>
+    <tr>
+        <td width=80> <img src="https://avatars.githubusercontent.com/u/271874822?s=200&v=4" alt="SandBase" width="64" height="auto" /> </td>
+        <td> <a href="https://github.com/sandbaseai/sandbase-harness">SandBase Harness</a> </td>
+        <td>本地优先的托管智能体运行时，提供持久会话、沙箱执行、MCP、审计与回放，并已验证支持 DeepSeek V4 推理强度控制。</td>
+    </tr>
         <tr>
         <td> <img src="https://avatars.githubusercontent.com/u/182288589?s=200&v=4" alt="Icon" width="64" height="auto" /> </td>
         <td> <a href="https://github.com/DMontgomery40/deepseek-mcp-server/blob/main/README.md">DeepSeek MCP Server</a> </td>


### PR DESCRIPTION
## Summary

Add [SandBase Harness](https://github.com/sandbaseai/sandbase-harness) to the **AI Agent frameworks** section in both English and Simplified Chinese.

## Why it belongs

SandBase Harness is an actively maintained, local-first managed agent runtime with durable sessions, sandboxed execution, MCP, audit, and replay. Its DeepSeek integration is implemented and verified:

- DeepSeek V4 Pro and Flash through an OpenAI-compatible endpoint
- `reasoning_effort: max` forwarding
- DeepSeek Harness stdio MCP bridge and Cordis bundle
- containerized MCP bridge through `Dockerfile.mcp`
- immutable [v0.3.2 release](https://github.com/sandbaseai/sandbase-harness/releases/tag/v0.3.2)
- complete release gate: typechecking, tests, runtime and Console production builds, package validation, and release smoke checks

## Validation

- public working repository and avatar links
- English and Simplified Chinese entries
- balanced table markup for both added rows
- `git diff --check`

## Relationship disclosure

I am affiliated with SandBase AI. This contribution was prepared with AI assistance on behalf of the SandBase project.
