### PR TITLE
Add MCP Lens for DeepSeek Harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -620,6 +620,11 @@ With these functionalities, the AI assistant can summarize key points within an 
         <td> <a href="https://github.com/guyoung/AIMatrices/blob/main/README.md">AIMatrices</a> </td>
         <td>AIMatrices is a lightweight, high-performance, scalable, and open source AI application rapid building platform designed to provide developers with an efficient and convenient AI application development experience. It integrates multiple advanced technologies and tools to help users quickly build, deploy, and maintain AI applications without having to write complex code from scratch.</td>
     </tr>
+    <tr>
+        <td> <img src="https://raw.githubusercontent.com/labmimors/dsh-mcp-lens/main/site/favicon.svg" alt="MCP Lens icon" width="64" height="auto" /> </td>
+        <td> <a href="https://github.com/labmimors/dsh-mcp-lens">MCP Lens</a> </td>
+        <td>An open-source DeepSeek Harness plugin that keeps large MCP catalogs behind two model-facing interfaces, connects MCP servers lazily, and enforces workspace tool allow/deny controls.</td>
+    </tr>
 </table>
 
 ### RAG frameworks

--- a/README_cn.md
+++ b/README_cn.md
@@ -529,6 +529,11 @@
         <td> <a href="https://github.com/Tencent/Youtu-agent/"> Youtu-Agent </a> </td>
         <td> <a href="https://github.com/Tencent/Youtu-agent/"> Youtu-Agent </a> 是一个灵活、高性能的框架，用于构建、运行和评估自主智能体。除了在基准测试中名列前茅，该框架还提供了强大的智能体能力，采用开源模型即可实现例如数据分析、文件处理、深度研究等功能。 </td>
     </tr>
+    <tr>
+        <td> <img src="https://raw.githubusercontent.com/labmimors/dsh-mcp-lens/main/site/favicon.svg" alt="MCP Lens 图标" width="64" height="auto" /> </td>
+        <td> <a href="https://github.com/labmimors/dsh-mcp-lens">MCP Lens</a> </td>
+        <td>一个开源的 DeepSeek Harness 插件，通过两个面向模型的接口管理大型 MCP 工具目录，按需连接 MCP 服务器，并执行工作区级工具允许/拒绝策略。</td>
+    </tr>
 </table>
 
 <p style="text-align: right;"><a href="#目录">^ 返回目录 ^</a></p>


### PR DESCRIPTION
## Summary

- add MCP Lens to the AI Agent frameworks table
- include matching English and Simplified Chinese entries
- describe only its model-facing interface, lazy MCP connection, and workspace policy boundaries

## Why it fits

MCP Lens is an open-source plugin for the official DeepSeek Harness agent runtime. It lets Harness use MCP catalogs through `mcp_search` and `mcp_call` while retaining per-workspace allow/deny controls.

Disclosure: `@labmimors` maintains the submitted MCP Lens project.

## Validation

- `git diff --check`
- balanced `<tr>` / `</tr>` counts in both edited READMEs
- repository and referenced SVG returned HTTP 200
- source-backed verification of the two registered interfaces, lazy connection behavior, and allow/deny enforcement