### PR TITLE
Add ClawMetry to Others

### DIFF
--- a/README.md
+++ b/README.md
@@ -1310,6 +1310,11 @@ The purpose is to build infrastructure in the field of large models, through the
         <td> <a href="https://github.com/informatico-madrid/blackwell-linux-infra-optimizer"> Blackwell Linux Infra Optimizer </a> </td>
         <td> Optimized vLLM stack for NVIDIA Blackwell (SM_120) and Linux Kernel 6.14. Achieving 59.0 t/s on DeepSeek-R1-32B using native FlashInfer backend. </td>
     </tr>
+    <tr>
+        <td> <img src="https://clawmetry.com/favicon.png" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://github.com/vivekchand/clawmetry"> ClawMetry </a> </td>
+        <td> ClawMetry is an open-source, zero-config dashboard that monitors DeepSeek Harness (dsh) sessions and tracks DeepSeek API token usage and costs locally, alongside 20+ other AI agent runtimes. </td>
+    </tr>
 </table>
 
 <p style="text-align: right;"><a href="#table-of-contents">^ Back to Contents ^</a></p>

--- a/README_cn.md
+++ b/README_cn.md
@@ -1005,6 +1005,11 @@
         <td> <a href="https://github.com/sally-suite/open-office-copilot">Open Office Copilot</a> </td>
         <td> Open Office Copilot 是一个开源的 Office 助手，支持 Microsoft Office 和 Google Workspace，基于 AI-Agent。它可以帮助你在 Word 中写作、在 PowerPoint 中生成幻灯片、在 Excel 中分析数据、在 Outlook 里帮你生成邮件等，现在已经集成了 DeepSeek。</td>
     </tr>
+    <tr>
+        <td> <img src="https://clawmetry.com/favicon.png" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://github.com/vivekchand/clawmetry"> ClawMetry </a> </td>
+        <td> ClawMetry 是一个开源、零配置的仪表盘，可在本地监控 DeepSeek Harness（dsh）会话，并跟踪 DeepSeek API 的 token 用量和成本，同时支持 20 多种其他 AI 智能体运行时。 </td>
+    </tr>
 </table>
 
 <p style="text-align: right;"><a href="#目录">^ 返回目录 ^</a></p>


### PR DESCRIPTION
Adds ClawMetry to the Others section, following the existing table row format with a 64px icon. It is an open-source, zero-config dashboard that monitors DeepSeek Harness (dsh) sessions and tracks DeepSeek API token usage and costs locally. The same entry is mirrored in README_cn.md with a Chinese description.

Website: https://clawmetry.com
