### PR TITLE
Add dsh-usage-dashboard to Others (DeepSeek Harness usage analytics plugin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1310,6 +1310,12 @@ The purpose is to build infrastructure in the field of large models, through the
         <td> <a href="https://github.com/informatico-madrid/blackwell-linux-infra-optimizer"> Blackwell Linux Infra Optimizer </a> </td>
         <td> Optimized vLLM stack for NVIDIA Blackwell (SM_120) and Linux Kernel 6.14. Achieving 59.0 t/s on DeepSeek-R1-32B using native FlashInfer backend. </td>
     </tr>
+    <tr>
+        <td style="font-size: 64px">&#128202;</td>
+        <td> <a href="https://github.com/woosh2010/dsh-usage-dashboard"> dsh-usage-dashboard </a></td>
+        <td> A DeepSeek Harness (dsh) plugin: peak/valley billing dock and usage analytics dashboard for DeepSeek API usage (token/cost/model stats, live balance, cross-session history). </td>
+    </tr>
+
 </table>
 
 <p style="text-align: right;"><a href="#table-of-contents">^ Back to Contents ^</a></p>


### PR DESCRIPTION
Adds **dsh-usage-dashboard** (https://github.com/woosh2010/dsh-usage-dashboard) under the Others category.

It is a plugin for DeepSeek Harness (dsh) that tracks DeepSeek API usage: a peak/valley billing dock under the chat composer (Beijing-time peak 9:00–12:00 / 14:00–18:00 at full price, valley at half price), the live DeepSeek account balance via the official `/user/balance` API, and a cross-session analytics dashboard (token/cost/model stats, cost trend, token-mix, latest 20 turns of step records, global time/session/model filters).

- MIT license, docs in 7 languages
- Repo carries the `dsh-plugin` topic
- Install: `dsh plugin --profile web add https://github.com/woosh2010/dsh-usage-dashboard/releases/download/v0.4.0/deepseek-ai-dsh-client-ui-usage-0.4.0.tgz`