### PR TITLE
Add TeamoRouter to Providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1148,6 +1148,11 @@ The purpose is to build infrastructure in the field of large models, through the
         <td> <a href="https://docs.aimlapi.com/api-references/text-models-llm?utm_source=awesome-deepseek-integrations&utm_medium=github&utm_campaign=integration"> AI/ML API </a> </td>
         <td> AI/ML API gives users enterprise-grade access to 200+ models with just one API. This includes Deepseek R1 and V3, alongside closed and open-source models. All at 99% uptime and with 24/7 human support.</td>
     </tr>
+    <tr>
+        <td> <b>TeamoRouter</b> </td>
+        <td> <a href="https://teamorouter.cn?utm_source=github&utm_medium=awesome-list&utm_campaign=integration"> TeamoRouter </a> </td>
+        <td> TeamoRouter is an LLM gateway aggregating DeepSeek R1/V3, Claude, GPT &amp; Gemini under one OpenAI-compatible API — unified routing, per-key billing and auditable cost control for production apps.</td>
+    </tr>
 </table>
 
 <p style="text-align: right;"><a href="#table-of-contents">^ Back to Contents ^</a></p>


### PR DESCRIPTION
Add TeamoRouter to the Providers section.

TeamoRouter is an LLM gateway aggregating DeepSeek R1/V3, Claude, GPT and Gemini under one OpenAI-compatible API — unified routing, per-key billing and auditable cost control for production apps and CLI tools (Claude Code / Codex).

Links:
- Gateway: https://teamorouter.cn?utm_source=github&utm_medium=awesome-list&utm_campaign=integration
- Relay platform guide: https://teamorouter.cn/blogs/ai-zhongzhuan-pingtai-tuijian
- API docs: https://teamorouter.cn/docs/api-integration
