### PR TITLE
Add Occurrence-Development Logic (ODL) to AI Agent frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,6 +565,11 @@ With these functionalities, the AI assistant can summarize key points within an 
 
 <table>
     <tr>
+        <td><img src="https://avatars.githubusercontent.com/u/197203477?s=200&v=4" alt="Icon" width="64" height="auto" /></td>
+        <td><a href="https://github.com/1frank-art/occurrence-development-logic">Occurrence-Development Logic (ODL)</a></td>
+        <td>A runtime configuration discipline layer for Agent output discipline and long-horizon consistency: four-step occurrence-development logic (sentence-type splitting, spatiotemporal tree, classified responses, self-check), loadable as a System Prompt or DeepSeek Harness skill. MIT.</td>
+    </tr>
+  <tr>
         <td width=80> <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/smolagents/mascot_smol.png" alt="Icon" width="64" height="auto" /> </td>
         <td> <a href="https://github.com/huggingface/smolagents/tree/main"> smolagents </a> </td>
         <td> The simplest way to build great agents. Agents write python code to call tools and orchestrate other agents. Priority support for open models like DeepSeek-R1!  </td>

--- a/README_cn.md
+++ b/README_cn.md
@@ -479,6 +479,11 @@
 
 <table>
         <tr>
+        <td><img src="https://avatars.githubusercontent.com/u/197203477?s=200&v=4" alt="Icon" width="64" height="auto" /></td>
+        <td><a href="https://github.com/1frank-art/occurrence-development-logic">发生发展逻辑模型（ODL）</a></td>
+        <td>面向 Agent 输出纪律与长程一致性的运行时配置纪律层：四步发生发展逻辑（句型拆分、时空树定位、按类回应、自检），以 System Prompt 或 DeepSeek Harness skill 加载。MIT。</td>
+    </tr>
+ <tr>
         <td> <img src="https://avatars.githubusercontent.com/u/182288589?s=200&v=4" alt="Icon" width="64" height="auto" /> </td>
         <td> <a href="https://github.com/DMontgomery40/deepseek-mcp-server/blob/main/README.md">DeepSeek MCP Server</a> </td>
         <td> 用于 DeepSeek 高级语言模型的 Model Context Protocol 服务器</td>


### PR DESCRIPTION
## What
Add [occurrence-development-logic](https://github.com/1frank-art/occurrence-development-logic) to the AI Agent frameworks section (both README.md and README_cn.md).

Occurrence-Development Logic (ODL) is a runtime configuration discipline layer for Agent output discipline and long-horizon consistency, loadable as a System Prompt or a DeepSeek Harness skill. MIT.

## Evidence
Three-arm blind tests, 86 questions (A=bare, B=with manual v2.5, C=length-matched neutral placebo; deepseek-chat / deepseek-reasoner / deepseek-v4-pro; blind judging; z-test + 95% CI + Bonferroni correction; dual-judge kappa=0.466):
- source citation rate +67.8pp (significant)
- boundary declaration rate +36.7pp (significant)
- element-coverage strictness +19.0pp (significant)
- length efficiency: -69% output length at equal quality (367 vs 1170 chars)
- placebo clean, zero side effects
- boundaries disclosed: TruthfulQA ceiling (native honesty 91.7%), no effect on IFEval format compliance

## Checklist
- [x] README.md entry added
- [x] README_cn.md entry added
- [x] Entry links to the project repo