### PR TITLE
Add TeamoRouter to Providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1148,6 +1148,11 @@ The purpose is to build infrastructure in the field of large models, through the
         <td> <a href="https://docs.aimlapi.com/api-references/text-models-llm?utm_source=awesome-deepseek-integrations&utm_medium=github&utm_campaign=integration"> AI/ML API </a> </td>
         <td> AI/ML API gives users enterprise-grade access to 200+ models with just one API. This includes Deepseek R1 and V3, alongside closed and open-source models. All at 99% uptime and with 24/7 human support.</td>
     </tr>
+    <tr>
+        <td style="font-size: 64px">🛰️</td>
+        <td> <a href="https://teamorouter.cn"> TeamoRouter </a> </td>
+        <td> TeamoRouter is an OpenAI-compatible API gateway serving DeepSeek V4 Pro and V4 Flash, with permanent free daily tiers of both (no credit card required). One key also speaks the Anthropic Messages protocol natively, so the same endpoint works for Claude Code, Codex and DeepSeek SDK apps.</td>
+    </tr>
 </table>
 
 <p style="text-align: right;"><a href="#table-of-contents">^ Back to Contents ^</a></p>


### PR DESCRIPTION
Adds [TeamoRouter](https://teamorouter.cn) to the **Providers** section, following the existing commercial-provider precedent (AI/ML API).

**What it offers for DeepSeek users:**
- OpenAI-compatible gateway serving **DeepSeek V4 Pro and V4 Flash** — base URL `https://api.teamorouter.cn/v1`, works with the official DeepSeek/OpenAI SDKs
- **Permanent free daily tiers** of both models granted at registration (V4 Flash: 50 req/day; V4 Pro: 200 req/day), no credit card — a zero-cost way to try V4 in any of the apps listed in this repo
- One key also speaks the **Anthropic Messages protocol** natively, so the same endpoint serves Claude Code, Codex (`/v1/responses`) and OpenAI-SDK apps without local protocol conversion

Quick start:

```bash
export DEEPSEEK_BASE_URL=https://api.teamorouter.cn/v1
export DEEPSEEK_API_KEY=sk-teamo-xxxx
```

Useful links:
- https://teamorouter.cn (landing page)
- https://teamorouter.cn/docs (API docs)
- https://github.com/deepseek-ai (upstream DeepSeek)