### PR TITLE
docs: add PairCode to AI Code Editor section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1102,6 +1102,12 @@ The purpose is to build infrastructure in the field of large models, through the
         <td> <a href="docs/wusigram/README.md"> 无思微程序 </a> </td>
         <td>A mobile AI code writing and running tool. DeepSeek Programming Companion</td>
     </tr>
+    <tr>
+        <td> <img src="docs/PairCode/assets/logo.svg" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://github.com/hoonfeng/paircode"> PairCode </a> </td>
+        <td> A local-first AI coding assistant &amp; agent platform written in Go. DeepSeek is the built-in default provider of its Web IDE, powering a turn/step dual-loop agent runtime with everything-as-plugins UI, code graph, semantic search, persistent memory, sub-agent orchestration and MCP support. </td>
+    </tr>
+
 </table>
 
 <p style="text-align: right;"><a href="#table-of-contents">^ Back to Contents ^</a></p>

--- a/README_cn.md
+++ b/README_cn.md
@@ -901,6 +901,12 @@
         <td> <a href="docs/wusigram/README_cn.md"> 无思微程序 </a> </td>
         <td> 移动端AI编程和运行工具，DeepSeek编程搭档 </td>
     </tr>
+    <tr>
+        <td> <img src="docs/PairCode/assets/logo.svg" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://github.com/hoonfeng/paircode"> PairCode </a> </td>
+        <td> 基于 Go 的本地优先 AI 编程助手与 Agent 平台：内置 DeepSeek API 为默认模型供应商，Web IDE 搭载 turn/step 双循环 Agent 运行时，支持一切皆插件、代码图谱、语义搜索、持久记忆、子 Agent 编排与 MCP。 </td>
+    </tr>
+
 </table>
 
 <p style="text-align: right;"><a href="#目录">^ 返回目录 ^</a></p>

--- a/README_es.md
+++ b/README_es.md
@@ -881,6 +881,12 @@ Integra la API de DeepSeek en softwares populares. Accede a la [Plataforma Abier
         <td> <a href="docs/wusigram/README.md"> 无思微程序 </a> </td>
         <td>Herramientas de programación y operación de IA móvil, socio de programación de DeepSeek</td>
     </tr>
+    <tr>
+        <td> <img src="docs/PairCode/assets/logo.svg" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://github.com/hoonfeng/paircode"> PairCode </a> </td>
+        <td> Asistente de codificación IA y plataforma de agentes local-first escrita en Go. DeepSeek es el proveedor predeterminado incorporado: Web IDE con runtime de agente de doble bucle turn/step, UI basada en plugins, grafo de código, búsqueda semántica, memoria persistente, orquestación de subagentes y soporte MCP. </td>
+    </tr>
+
 </table>
 
 <p style="text-align: right;"><a href="#tabla-de-contenidos">^ Volver al índice ^</a></p>

--- a/README_ja.md
+++ b/README_ja.md
@@ -781,6 +781,12 @@ DeepSeek API を人気のソフトウェアに統合します。API キーを取
         <td> <a href="docs/wusigram/README.md"> 无思微程序 </a> </td>
         <td>モバイルAIプログラミングおよび運用ツール、DeepSeekプログラミングパートナー</td>
     </tr>
+    <tr>
+        <td> <img src="docs/PairCode/assets/logo.svg" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://github.com/hoonfeng/paircode"> PairCode </a> </td>
+        <td> Goで構築されたローカルファーストのAIコーディングアシスタント＆Agentプラットフォーム。DeepSeek APIをデフォルトプロバイダーとして内蔵し、turn/step二重ループのAgentランタイム、プラグイン化UI、コードグラフ、セマンティック検索、永続メモリ、サブエージェント編成、MCPをサポートします。 </td>
+    </tr>
+
 </table>
 
 <p style="text-align: right;"><a href="#目次">^ 目次に戻る ^</a></p>

--- a/README_zh_tw.md
+++ b/README_zh_tw.md
@@ -946,6 +946,12 @@
         <td> <a href="docs/wusigram/README_cn.md"> 无思微程序 </a> </td>
         <td>行動端AI程式設計與運行工具，DeepSeek程式設計搭檔</td>
     </tr>
+    <tr>
+        <td> <img src="docs/PairCode/assets/logo.svg" alt="Icon" width="64" height="auto" /> </td>
+        <td> <a href="https://github.com/hoonfeng/paircode"> PairCode </a> </td>
+        <td> 基於 Go 的本地優先 AI 程式助手與 Agent 平台：內建 DeepSeek API 為預設模型供應商，Web IDE 搭載 turn/step 雙循環 Agent 執行時，支援一切皆插件、程式碼圖譜、語意搜尋、持久記憶、子 Agent 編排與 MCP。 </td>
+    </tr>
+
 </table>
 
 <p style="text-align: right;"><a href="#目錄">^ 返回目錄 ^</a></p>

--- a/docs/PairCode/assets/logo.svg
+++ b/docs/PairCode/assets/logo.svg
@@ -1,0 +1,61 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
+  <defs>
+    <!-- 背景渐变（深色科技风） -->
+    <linearGradient id="bgGrad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0a1628"/>
+      <stop offset="100%" stop-color="#0d1f2e"/>
+    </linearGradient>
+    <!-- 左侧尖括号渐变（科技蓝） -->
+    <linearGradient id="leftBracket" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#00d4ff"/>
+      <stop offset="100%" stop-color="#0077b6"/>
+    </linearGradient>
+    <!-- 右侧尖括号渐变（科技绿） -->
+    <linearGradient id="rightBracket" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#00e676"/>
+      <stop offset="100%" stop-color="#00c853"/>
+    </linearGradient>
+    <!-- 中间连接线（蓝绿渐变） -->
+    <linearGradient id="connector" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#00d4ff"/>
+      <stop offset="50%" stop-color="#00e5ff"/>
+      <stop offset="100%" stop-color="#00e676"/>
+    </linearGradient>
+    <!-- 外发光 -->
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <filter id="softGlow">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+
+  <!-- 圆角方形背景（深色科技底） -->
+  <rect x="32" y="32" width="448" height="448" rx="96" ry="96" fill="url(#bgGrad)" stroke="#1a3a4a" stroke-width="2"/>
+
+  <!-- 左侧 < 尖括号（三段式直线 — 科技蓝，代表代码输入/开发者） -->
+  <path d="M180 150 L96 256 L180 362"
+        stroke="url(#leftBracket)" stroke-width="40" stroke-linejoin="round" fill="none"
+        filter="url(#glow)"/>
+
+  <!-- 右侧 > 尖括号（三段式直线 — 科技绿，代表代码输出/AI伙伴） -->
+  <path d="M332 150 L416 256 L332 362"
+        stroke="url(#rightBracket)" stroke-width="40" stroke-linejoin="round" fill="none"
+        filter="url(#glow)"/>
+
+  <!-- 中间「=」连接线已移除（图标只留 < > 尖括号 + 中心 AI 核心光点）。 -->
+
+  <!-- 中心光点（代表 AI 核心 — 亮青色） -->
+  <circle cx="256" cy="256" r="18" fill="transparent" stroke="#00e5ff" stroke-width="3" opacity="0.6"/>
+  <circle cx="256" cy="256" r="8" fill="#00e5ff" opacity="0.9">
+    <animate attributeName="opacity" values="0.6;1;0.6" dur="2s" repeatCount="indefinite"/>
+  </circle>
+</svg>


### PR DESCRIPTION
## Summary
Adding [PairCode](https://github.com/hoonfeng/paircode) to the **Native AI Code Editor** section.

**PairCode** — local-first AI coding assistant & agent platform written in Go:
- DeepSeek is the built-in default provider (config/ai-presets.json), powering a turn/step dual-loop agent runtime in its Web IDE (localhost:9090)
- Everything-as-plugins: disk plugin packages + JS/goja sandbox + Node bridge
- Code graph, semantic search (local ONNX), persistent memory, sub-agent orchestration, MCP support

## Changes
- Updated all 5 language READMEs (EN / 简中 / 繁中 / JA / ES)
- Added logo: docs/PairCode/assets/logo.svg