### PR TITLE
Add translating hacker news

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,6 +557,11 @@ With these functionalities, the AI assistant can summarize key points within an 
         <td> <a href="https://github.com/songquanpeng/one-api">One API</a> </td>
         <td> One API is a LLM API management & key redistribution system, unifying multiple providers under a single API. Single binary, Docker-ready, with an English UI.</td>
     </tr>
+    <tr>
+        <td><img src="https://aidoge.ai/resource/TranslatingHackerNewsIcon.jpg" alt="Icon" width="64" height="auto" /></td>
+        <td><a href="docs/translating-hacker-news/README.md">Translating Hacker News</a></td>
+        <td>Translating Hacker News is an iOS Hacker News reader that translates stories, comments, and linked articles in place. It uses the official DeepSeek API (BYOK) because DeepSeek is fast, low-cost, and lets you edit the translation prompt to fit HN discussions.</td>
+    </tr>
 </table>
 
 <p style="text-align: right;"><a href="#table-of-contents">^ Back to Contents ^</a></p>

--- a/README_cn.md
+++ b/README_cn.md
@@ -471,6 +471,11 @@
         <td> <a href="https://www.aispire.info">AIspire</a> </td>
         <td> AIspire是一个辅助AI学术写作的全能助手，从学术问题解答、学术灵感发现、文献管理、辅助阅读到全自动化AI辅助写作，让你的科研更精准、更高效。 </td>
     </tr>
+    <tr>
+        <td><img src="https://aidoge.ai/resource/TranslatingHackerNewsIcon.jpg" alt="Icon" width="64" height="auto" /></td>
+        <td><a href="docs/translating-hacker-news/README_cn.md">黑客新闻翻译</a></td>
+        <td>黑客新闻翻译是一款可将故事、评论和外链文章就地翻译的 iOS Hacker News 阅读器。接入 DeepSeek 官方 API（自备 Key），翻译速度快、成本低，并支持自定义提示词以适配 HN 讨论风格。</td>
+    </tr>
 </table>
 
 <p style="text-align: right;"><a href="#目录">^ 返回目录 ^</a></p>

--- a/README_es.md
+++ b/README_es.md
@@ -123,7 +123,7 @@ Integra la API de DeepSeek en softwares populares. Accede a la [Plataforma Abier
     <tr>
         <td> <img src="./docs/Coco AI/assets/favicon.png" alt="Icono" width="64" height="auto" /> </td>
         <td> <a href="docs/Coco AI/README.md">Coco AI</a></td>
-        <td> <a href="https://coco.rs">Coco AI</a> es una herramienta de búsqueda y productividad unificada, completamente de código abierto y multiplataforma, que conecta y busca en diversas fuentes de datos, incluyendo aplicaciones, archivos, Google Drive, Notion, Yuque, Hugo y más, tanto locales como en la nube. Al integrarse con modelos grandes como `DeepSeek`, Coco AI permite una gestión inteligente del conocimiento personal, destacando la privacidad y admitiendo despliegues privados, ayudando a los usuarios a acceder rápidamente a su información de manera inteligente.</td>
+        <td> <a href="https://coco.rs">Coco AI</a> es una herramienta de búsqueda y productividad unificada, completamente de código abierto y multiplataforma, que conecta y busca en diversas fuentes de datos, incluyendo aplicaciones, archivos, Google Drive, Notion, Yuque, Hugo y más, tanto locales como en la nube. Al integrarse con modelos grandes como DeepSeek, Coco AI permite una gestión inteligente del conocimiento personal, destacando la privacidad y admitiendo despliegues privados, ayudando a los usuarios a acceder rápidamente a su información de manera inteligente.</td>
     </tr>
     <tr>
         <td> <img src="./docs/liubai/assets/liubai-logo.png" alt="Icono" width="64" height="auto" /> </td>

--- a/README_es.md
+++ b/README_es.md
@@ -123,7 +123,7 @@ Integra la API de DeepSeek en softwares populares. Accede a la [Plataforma Abier
     <tr>
         <td> <img src="./docs/Coco AI/assets/favicon.png" alt="Icono" width="64" height="auto" /> </td>
         <td> <a href="docs/Coco AI/README.md">Coco AI</a></td>
-        <td> <a href="https://coco.rs">Coco AI</a> es una herramienta de búsqueda y productividad unificada, completamente de código abierto y multiplataforma, que conecta y busca en diversas fuentes de datos, incluyendo aplicaciones, archivos, Google Drive, Notion, Yuque, Hugo y más, tanto locales como en la nube. Al integrarse con modelos grandes como DeepSeek, Coco AI permite una gestión inteligente del conocimiento personal, destacando la privacidad y admitiendo despliegues privados, ayudando a los usuarios a acceder rápidamente a su información de manera inteligente.</td>
+        <td> <a href="https://coco.rs">Coco AI</a> es una herramienta de búsqueda y productividad unificada, completamente de código abierto y multiplataforma, que conecta y busca en diversas fuentes de datos, incluyendo aplicaciones, archivos, Google Drive, Notion, Yuque, Hugo y más, tanto locales como en la nube. Al integrarse con modelos grandes como `DeepSeek`, Coco AI permite una gestión inteligente del conocimiento personal, destacando la privacidad y admitiendo despliegues privados, ayudando a los usuarios a acceder rápidamente a su información de manera inteligente.</td>
     </tr>
     <tr>
         <td> <img src="./docs/liubai/assets/liubai-logo.png" alt="Icono" width="64" height="auto" /> </td>
@@ -431,6 +431,11 @@ Integra la API de DeepSeek en softwares populares. Accede a la [Plataforma Abier
         <td width=80> <img src="docs/turtlenoir/assets/logo.png" alt="Icon" width="64" height="auto" /> </td>
         <td> <a href="https://turtlenoir.com/"> Turtle Noir </a> </td>
         <td> <a href="https://turtlenoir.com/"> Turtle Noir </a> Un juego de enigmas de pensamiento lateral tipo "Sopa de Tortuga" con un anfitrión de IA basado en DeepSeek, disponible para uno o varios jugadores. La IA modera la partida e interactúa con humor, guiando la deducción mediante respuestas de "Sí / No / Irrelevante". Ofrece una experiencia inmersiva con una fuerte atmósfera narrativa, gestión del ritmo y un sistema de pistas para evitar bloqueos. Integra búsqueda vectorial y DeepSeek para evitar la repetición de acertijos e incluye moderación de contenido. Ideal para entrenar la creatividad y como entretenimiento social en línea. </td>
+    </tr>
+    <tr>
+        <td><img src="https://aidoge.ai/resource/TranslatingHackerNewsIcon.jpg" alt="Icon" width="64" height="auto" /></td>
+        <td><a href="docs/translating-hacker-news/README_es.md">Translating Hacker News</a></td>
+        <td>Translating Hacker News es un lector de Hacker News para iOS que traduce historias, comentarios y artículos enlazados en el acto. Usa la API oficial de DeepSeek (BYOK) porque es rápida, económica y permite editar el prompt de traducción.</td>
     </tr>
 </table>
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -404,6 +404,11 @@ DeepSeek API を人気のソフトウェアに統合します。API キーを取
         <td> <a href="https://github.com/guyoung/AIMatrices/blob/main/README.md">AIMatrices</a> </td>
         <td>AIMatricesは、効率的で便利なaiアプリケーション開発体験を開発者に提供するために設計された、軽量、高性能、スケーラブルでオープンソースのaiアプリケーション迅速構築プラットフォームです。複数の高度なテクノロジとツールを統合することで、複雑なコードをゼロから作成することなく、ユーザーがaiアプリケーションを迅速に構築、展開、維持できるようになります。</td>
     </tr>
+    <tr>
+        <td><img src="https://aidoge.ai/resource/TranslatingHackerNewsIcon.jpg" alt="Icon" width="64" height="auto" /></td>
+        <td><a href="docs/translating-hacker-news/README_ja.md">Translating Hacker News</a></td>
+        <td>Translating Hacker News は、ストーリー、コメント、リンク先記事をその場で翻訳する iOS 向け Hacker News リーダーです。公式 DeepSeek API（BYOK）を採用し、高速・低コストで、HN 向けに翻訳プロンプトを編集できます。</td>
+    </tr>
 </table>
 
 <p style="text-align: right;"><a href="#目次">^ 目次に戻る ^</a></p>

--- a/README_zh_tw.md
+++ b/README_zh_tw.md
@@ -470,6 +470,11 @@
         <td> <a href="https://haiguitang.net/"> Turtle Noir </a> </td>
         <td> <a href="https://haiguitang.net/"> Turtle Noir </a> 基於 DeepSeek 的 AI 主持人海龜湯 / 側向思維解謎產品，可單人或者多人遊玩。AI 進行控場與吐槽，圍繞「是 / 否 / 無關」的問答推進推理；提供沉浸式玩法（更強劇情氛圍與節奏引導）、引導提示與防卡關機制，同時結合向量檢索 + DeepSeek 進行題目去重，並提供內容審核能力。適合輕量腦洞訓練與在線陪玩。 </td>
     </tr>
+    <tr>
+        <td><img src="https://aidoge.ai/resource/TranslatingHackerNewsIcon.jpg" alt="Icon" width="64" height="auto" /></td>
+        <td><a href="docs/translating-hacker-news/README_zh_tw.md">黑客新聞翻譯</a></td>
+        <td>黑客新聞翻譯是一款可將故事、評論和外鏈文章就地翻譯的 iOS Hacker News 閱讀器。接入 DeepSeek 官方 API（自備 Key），翻譯速度快、成本低，並支援自訂提示詞以適配 HN 討論風格。</td>
+    </tr>
 </table>
 
 <p style="text-align: right;"><a href="#目錄">^ 返回目錄 ^</a></p>

--- a/docs/translating-hacker-news/README.md
+++ b/docs/translating-hacker-news/README.md
@@ -1,0 +1,22 @@
+<img src="https://aidoge.ai/resource/TranslatingHackerNewsIcon.jpg" width="64" height="auto" />
+
+# Translating Hacker News
+
+Setup and live demo: [https://aidoge.ai/translating_hacker_news_intro.html](https://aidoge.ai/translating_hacker_news_intro.html)
+
+**Translating Hacker News** is an iOS Hacker News reader that translates stories, comments, and linked articles in place. It uses the official **DeepSeek API** (BYOK) because DeepSeek is fast, low-cost, and lets you edit the translation prompt to fit HN discussions.
+
+## UI
+
+<img src="https://is1-ssl.mzstatic.com/image/thumb/PurpleSource211/v4/5e/82/ea/5e82ea84-ad70-6785-8e6e-e56ea962df2d/iPhone_16_Pro_Max-01-app-launched.png/686x1024bb.jpg" width="280" alt="In-place feed translation" />
+<img src="https://is1-ssl.mzstatic.com/image/thumb/PurpleSource211/v4/d5/5b/7a/d55b7a61-80de-7f23-5e2d-265b55a3feb0/iPhone_16_Pro_Max-04-agent-configuration.png/686x1024bb.jpg" width="280" alt="DeepSeek agent configuration" />
+
+## Why DeepSeek
+
+- **Fast**: Default `deepseek-v4-flash` keeps titles and comment trees translating as you scroll.
+- **Low cost**: BYOK pricing stays cheap enough for continuous feed and thread translation.
+- **Custom prompts**: Edit the translation prompt (and temperature / Top P) so the tone matches technical HN discussions.
+
+## Integrate with DeepSeek API
+
+Open **Settings → AI Agent**, choose DeepSeek, and save your key from [DeepSeek Open Platform](https://platform.deepseek.com/api_keys).

--- a/docs/translating-hacker-news/README_cn.md
+++ b/docs/translating-hacker-news/README_cn.md
@@ -1,0 +1,22 @@
+<img src="https://aidoge.ai/resource/TranslatingHackerNewsIcon.jpg" width="64" height="auto" />
+
+# 黑客新闻翻译
+
+使用说明与现场演示：[https://aidoge.ai/zh/translating_hacker_news_intro.html](https://aidoge.ai/zh/translating_hacker_news_intro.html)
+
+**黑客新闻翻译（Translating Hacker News）** 是一款 iOS 上的 Hacker News 阅读器，可将故事、评论和外链文章就地翻译。App 接入 **DeepSeek 官方 API**（自备 Key），因为 DeepSeek 响应快、成本低，并且允许你改写适合 HN 讨论的提示词。
+
+## 界面预览
+
+<img src="https://is1-ssl.mzstatic.com/image/thumb/PurpleSource221/v4/28/1d/ce/281dce89-5095-8eae-096f-19b8d89b775c/iPhone_16_Pro_Max-01-app-launched.png/686x1024bb.jpg" width="280" alt="就地信息流翻译" />
+<img src="https://is1-ssl.mzstatic.com/image/thumb/PurpleSource211/v4/05/bb/62/05bb6242-d4cd-a2a8-49d7-25671285f60c/iPhone_16_Pro_Max-04-agent-configuration.png/686x1024bb.jpg" width="280" alt="DeepSeek 引擎配置" />
+
+## 为什么用 DeepSeek
+
+- **快**：默认 `deepseek-v4-flash`，刷信息流和展开评论树时都能跟上阅读节奏。
+- **便宜**：自备 Key，持续翻译标题和长讨论的成本更低。
+- **可改提示词**：可编辑翻译提示词（以及 Temperature / Top P），让译文更贴合 HN 的技术讨论语气。
+
+## 接入 DeepSeek API
+
+在 App 内打开 **设置 → AI Agent**，选择 DeepSeek，填入 [DeepSeek 开放平台](https://platform.deepseek.com/api_keys) 的 API Key 即可。

--- a/docs/translating-hacker-news/README_es.md
+++ b/docs/translating-hacker-news/README_es.md
@@ -1,0 +1,22 @@
+<img src="https://aidoge.ai/resource/TranslatingHackerNewsIcon.jpg" width="64" height="auto" />
+
+# Translating Hacker News
+
+Configuración y demostración en vivo: [https://aidoge.ai/es/translating_hacker_news_intro.html](https://aidoge.ai/es/translating_hacker_news_intro.html)
+
+**Translating Hacker News** es un lector de Hacker News para iOS que traduce historias, comentarios y artículos enlazados en el mismo flujo de lectura. Usa la **API oficial de DeepSeek** (BYOK) porque es rápida, económica y permite editar el prompt de traducción para adaptarlo a las discusiones de HN.
+
+## Interfaz
+
+<img src="https://is1-ssl.mzstatic.com/image/thumb/PurpleSource211/v4/5e/82/ea/5e82ea84-ad70-6785-8e6e-e56ea962df2d/iPhone_16_Pro_Max-01-app-launched.png/686x1024bb.jpg" width="280" alt="Traducción in situ del feed" />
+<img src="https://is1-ssl.mzstatic.com/image/thumb/PurpleSource211/v4/d5/5b/7a/d55b7a61-80de-7f23-5e2d-265b55a3feb0/iPhone_16_Pro_Max-04-agent-configuration.png/686x1024bb.jpg" width="280" alt="Configuración del agente DeepSeek" />
+
+## Por qué DeepSeek
+
+- **Rápido**: `deepseek-v4-flash` por defecto traduce títulos e hilos de comentarios mientras haces scroll.
+- **Bajo coste**: Con tu propia clave, traducir el feed y los hilos de forma continua sigue siendo económico.
+- **Prompts personalizables**: Edita el prompt de traducción (y temperature / Top P) para que el tono encaje con las discusiones técnicas de HN.
+
+## Integración con la API de DeepSeek
+
+Abre **Ajustes → AI Agent**, elige DeepSeek y guarda tu clave de [DeepSeek Open Platform](https://platform.deepseek.com/api_keys).

--- a/docs/translating-hacker-news/README_ja.md
+++ b/docs/translating-hacker-news/README_ja.md
@@ -1,0 +1,22 @@
+<img src="https://aidoge.ai/resource/TranslatingHackerNewsIcon.jpg" width="64" height="auto" />
+
+# Translating Hacker News
+
+セットアップとライブデモ：[https://aidoge.ai/ja/translating_hacker_news_intro.html](https://aidoge.ai/ja/translating_hacker_news_intro.html)
+
+**Translating Hacker News** は、ストーリー、コメント、リンク先の記事をその場で翻訳する iOS 向け Hacker News リーダーです。公式 **DeepSeek API**（BYOK）を使うのは、高速・低コストで、HN の議論に合うように翻訳プロンプトを編集できるからです。
+
+## UI
+
+<img src="https://is1-ssl.mzstatic.com/image/thumb/PurpleSource211/v4/5e/82/ea/5e82ea84-ad70-6785-8e6e-e56ea962df2d/iPhone_16_Pro_Max-01-app-launched.png/686x1024bb.jpg" width="280" alt="フィードのその場翻訳" />
+<img src="https://is1-ssl.mzstatic.com/image/thumb/PurpleSource211/v4/d5/5b/7a/d55b7a61-80de-7f23-5e2d-265b55a3feb0/iPhone_16_Pro_Max-04-agent-configuration.png/686x1024bb.jpg" width="280" alt="DeepSeek エージェント設定" />
+
+## なぜ DeepSeek か
+
+- **高速**：デフォルトの `deepseek-v4-flash` なら、スクロールしながらタイトルとコメントツリーを翻訳し続けられます。
+- **低コスト**：BYOK なら、フィードとスレッドを継続的に翻訳しても費用を抑えられます。
+- **カスタムプロンプト**：翻訳プロンプト（および temperature / Top P）を編集して、HN の技術的な議論に合うトーンにできます。
+
+## DeepSeek API の連携
+
+**設定 → AI Agent** で DeepSeek を選び、[DeepSeek Open Platform](https://platform.deepseek.com/api_keys) のキーを保存します。

--- a/docs/translating-hacker-news/README_zh_tw.md
+++ b/docs/translating-hacker-news/README_zh_tw.md
@@ -1,0 +1,22 @@
+<img src="https://aidoge.ai/resource/TranslatingHackerNewsIcon.jpg" width="64" height="auto" />
+
+# 黑客新聞翻譯
+
+使用說明與現場演示：[https://aidoge.ai/zh-hant/translating_hacker_news_intro.html](https://aidoge.ai/zh-hant/translating_hacker_news_intro.html)
+
+**黑客新聞翻譯（Translating Hacker News）** 是一款 iOS 上的 Hacker News 閱讀器，可將故事、評論和外鏈文章就地翻譯。App 接入 **DeepSeek 官方 API**（自備 Key），因為 DeepSeek 回應快、成本低，並且允許你改寫適合 HN 討論的提示詞。
+
+## 介面預覽
+
+<img src="https://is1-ssl.mzstatic.com/image/thumb/PurpleSource221/v4/28/1d/ce/281dce89-5095-8eae-096f-19b8d89b775c/iPhone_16_Pro_Max-01-app-launched.png/686x1024bb.jpg" width="280" alt="就地資訊流翻譯" />
+<img src="https://is1-ssl.mzstatic.com/image/thumb/PurpleSource211/v4/05/bb/62/05bb6242-d4cd-a2a8-49d7-25671285f60c/iPhone_16_Pro_Max-04-agent-configuration.png/686x1024bb.jpg" width="280" alt="DeepSeek 引擎設定" />
+
+## 為什麼用 DeepSeek
+
+- **快**：預設 `deepseek-v4-flash`，刷資訊流和展開評論樹時都能跟上閱讀節奏。
+- **便宜**：自備 Key，持續翻譯標題和長討論的成本更低。
+- **可改提示詞**：可編輯翻譯提示詞（以及 Temperature / Top P），讓譯文更貼合 HN 的技術討論語氣。
+
+## 接入 DeepSeek API
+
+在 App 內打開 **設定 → AI Agent**，選擇 DeepSeek，填入 [DeepSeek 開放平台](https://platform.deepseek.com/api_keys) 的 API Key 即可。


### PR DESCRIPTION
## Summary
Adds **Translating Hacker News**, an iOS Hacker News reader that translates stories, comments, and linked articles in place using the official DeepSeek API (BYOK).

## Why DeepSeek
- **Fast**: default `deepseek-v4-flash` keeps titles and comment trees translating as you scroll
- **Low cost**: BYOK pricing stays cheap enough for continuous feed and thread translation
- **Custom prompts**: users can edit the translation prompt, temperature, and Top P

## Changes
- Append one Applications row in all five READMEs (`README.md`, `README_cn.md`, `README_zh_tw.md`, `README_ja.md`, `README_es.md`)
- Add short docs under `docs/translating-hacker-news/` (en / cn / zh-tw / ja / es)
- Use hosted icon and App Store screenshots (no binary assets committed)

## Links
- Product intro / live demo: https://aidoge.ai/translating_hacker_news_intro.html
