### PR TITLE
docs: replace the dead RawGit Awesome badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <img width="1000px" alt="Awesome DeepSeek Integrations" src="docs/Awesome DeepSeek Integrations.png">
 </p>
 
-# Awesome DeepSeek Integrations ![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)
+# Awesome DeepSeek Integrations ![Awesome](https://awesome.re/badge.svg)
 
 Integrate the DeepSeek API into popular softwares. Access [DeepSeek Open Platform](https://platform.deepseek.com/) to get an API key.
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -4,7 +4,7 @@
 <img width="1280" alt="Awesome DeepSeek Integrations" src="docs/Awesome DeepSeek Integrations.png">
 </p>
 
-# DeepSeek 实用集成 ![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)
+# DeepSeek 实用集成 ![Awesome](https://awesome.re/badge.svg)
 
 将 DeepSeek 大模型能力轻松接入各类软件。访问 [DeepSeek 开放平台](https://platform.deepseek.com/) 来获取您的 API key。
 

--- a/README_es.md
+++ b/README_es.md
@@ -4,7 +4,7 @@
 <img width="1000px" alt="Integraciones Asombrosas de DeepSeek" src="docs/Awesome DeepSeek Integrations.png">
 </p>
 
-# Integraciones Asombrosas de DeepSeek ![Destacado](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)
+# Integraciones Asombrosas de DeepSeek ![Destacado](https://awesome.re/badge.svg)
 
 Integra la API de DeepSeek en softwares populares. Accede a la [Plataforma Abierta de DeepSeek](https://platform.deepseek.com/) para obtener una clave API.
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -4,7 +4,7 @@
 <img width="1000px" alt="Awesome DeepSeek Integrations" src="docs/Awesome DeepSeek Integrations.png">
 </p>
 
-# Awesome DeepSeek Integrations ![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)
+# Awesome DeepSeek Integrations ![Awesome](https://awesome.re/badge.svg)
 
 DeepSeek API を人気のソフトウェアに統合します。API キーを取得するには、[DeepSeek Open Platform](https://platform.deepseek.com/)にアクセスしてください。
 

--- a/README_zh_tw.md
+++ b/README_zh_tw.md
@@ -4,7 +4,7 @@
 <img width="1000px" alt="Awesome DeepSeek Integrations" src="docs/Awesome DeepSeek Integrations.png">
 </p>
 
-# 精彩的 DeepSeek 整合 ![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)
+# 精彩的 DeepSeek 整合 ![Awesome](https://awesome.re/badge.svg)
 
 將 DeepSeek API 整合到流行的軟體中。前往 [DeepSeek 開放平台](https://platform.deepseek.com/) 獲取 API 金鑰。
 


### PR DESCRIPTION
The Awesome badge in every language README points at `cdn.rawgit.com`, which was shut down in 2018. The hostname still resolves, but nothing answers it:

```
$ curl -sS -o /dev/null -w '%{http_code}\n' --max-time 20 \
    https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg
curl: (28) Connection timed out after 20013 milliseconds
000
```

so the header currently renders a broken image in all five translations.

The replacement is the current canonical URL for the same badge, which is what `sindresorhus/awesome` itself points at:

```
$ curl -sS -o /dev/null -w '%{http_code} %{content_type}\n' --max-time 20 https://awesome.re/badge.svg
200 image/svg+xml
```

Five files, one line each, so the headers stay consistent across translations:

- `README.md`
- `README_cn.md`
- `README_ja.md`
- `README_es.md`
- `README_zh_tw.md`

No other content is touched.
